### PR TITLE
Fix calendar bug

### DIFF
--- a/website/src/lib/components/toolbar/tools/Time.svelte
+++ b/website/src/lib/components/toolbar/tools/Time.svelte
@@ -34,7 +34,7 @@
 	let speed: number | undefined = undefined;
 
 	function toCalendarDate(date: Date): CalendarDate {
-		return new CalendarDate(date.getFullYear(), date.getMonth(), date.getDate());
+		return new CalendarDate(date.getFullYear(), date.getMonth() + 1, date.getDate());
 	}
 
 	const { velocityUnits, distanceUnits } = settings;
@@ -83,7 +83,7 @@
 			return new Date();
 		}
 		let [hours, minutes, seconds] = time.split(':').map((x) => parseInt(x));
-		return new Date(date.year, date.month, date.day, hours, minutes, seconds);
+		return new Date(date.year, date.month - 1, date.day, hours, minutes, seconds);
 	}
 
 	function updateEnd() {


### PR DESCRIPTION
Hello, thanks for this great tool.

When adding the time information to my trips I noticed both the UI and the generated GPX file resulted in a positive offset in the month date part.

I figured it was a problem when handling the `Date` and `CalendarDate` interface differences. `month` in the former means `indexed value` (0 for January) while `month` in the latter means the `value of the month` (1 for January).