### PR TITLE
Set interpolation mode to "monotone" to avoid backwards-going line

### DIFF
--- a/website/src/lib/components/ElevationProfile.svelte
+++ b/website/src/lib/components/ElevationProfile.svelte
@@ -104,7 +104,8 @@
 			line: {
 				pointRadius: 0,
 				tension: 0.4,
-				borderWidth: 2
+				borderWidth: 2,
+				cubicInterpolationMode: 'monotone'
 			}
 		},
 		interaction: {


### PR DESCRIPTION
This should fix #70.