### PR TITLE
Tab name: fallback to filename when name is empty

### DIFF
--- a/website/src/lib/stores.ts
+++ b/website/src/lib/stores.ts
@@ -269,9 +269,10 @@ export async function loadFile(file: File): Promise<GPXFile | null> {
             if (data) {
                 let gpx = parseGPX(data);
                 if (gpx.metadata === undefined) {
-                    gpx.metadata = { name: file.name.split('.').slice(0, -1).join('.') };
-                } else if (gpx.metadata.name === undefined) {
-                    gpx.metadata['name'] = file.name.split('.').slice(0, -1).join('.');
+                    gpx.metadata = {};
+                }
+                if (gpx.metadata.name === undefined || gpx.metadata.name.trim() === '') {
+                    gpx.metadata.name = file.name.split('.').slice(0, -1).join('.');
                 }
                 resolve(gpx);
             } else {


### PR DESCRIPTION
The tab name was already falling back to the file's name when the metadata `name` tag didn't exist but I had a few GPX files where the tag was there but was empty for some reason. I think it would be a good idea to also fallback to the file's name in that case, to avoid having empty tabs:
![Capture_2024-09-12_17:21:10](https://github.com/user-attachments/assets/484c824b-df57-4015-9a60-34d1fcaef865)
