### PR TITLE
Auto center on file select

### DIFF
--- a/website/src/lib/components/file-list/FileListNodeLabel.svelte
+++ b/website/src/lib/components/file-list/FileListNodeLabel.svelte
@@ -130,6 +130,12 @@
             'vertical'
                 ? 'h-fit'
                 : 'h-9 px-1.5 shadow-md'} pointer-events-auto"
+            on:click={() => {
+                if (!hidden) {
+                    selectItem(item);
+                    centerMapOnSelection();
+                }
+            }}
         >
             {#if item instanceof ListFileItem || item instanceof ListTrackItem}
                 <MetadataDialog bind:open={openEditMetadata} {node} {item} />


### PR DESCRIPTION
Sometimes it's difficult to find the route that has been selected on the map. Add automatic centering of the route upon selection in the files.