### PR TITLE
Hide start and finish marker when route is hidden

### DIFF
--- a/website/src/lib/components/gpx-layer/StartEndMarkers.ts
+++ b/website/src/lib/components/gpx-layer/StartEndMarkers.ts
@@ -1,4 +1,4 @@
-import { gpxStatistics, slicedGPXStatistics, currentTool, Tool } from '$lib/stores';
+import { gpxStatistics, slicedGPXStatistics, currentTool, Tool, allHidden } from '$lib/stores';
 import mapboxgl from 'mapbox-gl';
 import { get } from 'svelte/store';
 
@@ -25,12 +25,13 @@ export class StartEndMarkers {
         this.unsubscribes.push(gpxStatistics.subscribe(this.updateBinded));
         this.unsubscribes.push(slicedGPXStatistics.subscribe(this.updateBinded));
         this.unsubscribes.push(currentTool.subscribe(this.updateBinded));
+        this.unsubscribes.push(allHidden.subscribe(this.updateBinded));
     }
 
     update() {
         let tool = get(currentTool);
         let statistics = get(slicedGPXStatistics)?.[0] ?? get(gpxStatistics);
-        if (statistics.local.points.length > 0 && tool !== Tool.ROUTING) {
+        if (statistics.local.points.length > 0 && tool !== Tool.ROUTING && !get(allHidden)) {
             this.start.setLngLat(statistics.local.points[0].getCoordinates()).addTo(this.map);
             this.end
                 .setLngLat(


### PR DESCRIPTION
Fix when start and finish points are shown when track is hidden

<details>
<summary>Screenshot</summary>
<img width="815" height="803" alt="Screenshot 2025-08-16 at 15 36 48" src="https://github.com/user-attachments/assets/ba2b7796-7412-4e32-8332-05c5c82b09dc" />
</details>


