### PR TITLE
Add UK and RU lagnguages in interface

### DIFF
--- a/website/src/lib/languages.ts
+++ b/website/src/lib/languages.ts
@@ -11,4 +11,6 @@ export const languages: Record<string, string> = {
     'pt-BR': 'Português (Brasil)',
     tr: 'Türkçe',
     zh: '简体中文',
+    uk: 'Українська',
+    ru: 'Русский',
 };


### PR DESCRIPTION
I see there’s no translation for the documentation, but at least the application itself is translated. That’s better than nothing, right?