### PR TITLE
feat: support non-Mapbox basemaps without access token

### DIFF
--- a/website/src/lib/components/map/Map.svelte
+++ b/website/src/lib/components/map/Map.svelte
@@ -9,6 +9,8 @@
     import { page } from '$app/state';
     import { map } from '$lib/components/map/map';
 
+    const DUMMY_TOKEN = 'pk.dummy';
+
     let {
         accessToken = PUBLIC_MAPBOX_TOKEN,
         geolocate = true,
@@ -23,7 +25,7 @@
         class?: string;
     } = $props();
 
-    mapboxgl.accessToken = accessToken;
+    mapboxgl.accessToken = accessToken || DUMMY_TOKEN;
 
     let webgl2Supported = $state(true);
     let embeddedApp = $state(false);
@@ -48,7 +50,7 @@
             language = 'en';
         }
 
-        map.init(PUBLIC_MAPBOX_TOKEN, language, hash, geocoder, geolocate);
+        map.init(PUBLIC_MAPBOX_TOKEN || DUMMY_TOKEN, language, hash, geocoder, geolocate);
     });
 
     onDestroy(() => {


### PR DESCRIPTION
# Support non-Mapbox basemaps without access token

## Problem

The application required a Mapbox access token to function, even when using non-Mapbox basemaps (OpenStreetMap, CyclOSM, OpenTopoMap, etc.). Without a token, the map would appear completely black, making the application unusable.

Additionally, Mapbox GL JS requires an access token to be set, even if you're not using any Mapbox resources.

## Solution

This PR enables the application to work without a Mapbox access token by:

1. **Using a dummy token**: Mapbox GL JS requires a token to initialize, so we use `pk.dummy` as a placeholder when no real token is available.

2. **Conditional Mapbox resources**: Mapbox-specific resources (glyphs, sprites, DEM terrain) are only loaded when a valid token is present.

3. **Automatic fallback**: When a user selects a Mapbox basemap (like `mapboxOutdoors` or `mapboxSatellite`) but no token is available, the application automatically falls back to OpenStreetMap.

4. **Full support for non-Mapbox basemaps**: All non-Mapbox basemaps (OpenStreetMap, CyclOSM, OpenTopoMap, OpenHikingMap, etc.) now work perfectly without requiring a Mapbox token.

## Changes

### `map.ts`
- Extract `DUMMY_TOKEN` constant
- Improve type safety: `ImportSpecification[]` instead of `any[]`
- Conditionally add Mapbox glyphs/sprites only when token is valid
- Conditionally add Mapbox DEM terrain only when token is valid
- Conditionally add MapboxGeocoder only when token is valid

### `Map.svelte`
- Extract `DUMMY_TOKEN` constant
- Set dummy token when `PUBLIC_MAPBOX_TOKEN` is empty
- Pass dummy token to `map.init()` if needed

### `LayerControl.svelte`
- Add `requiresMapboxToken()` helper function
- Implement automatic fallback to OpenStreetMap for Mapbox basemaps without token
- Simplify `setStyle()` function
- Improve `addOverlay()` with better error handling and null checks
- Replace `hasOwnProperty` with modern `in` operator
- Fix `$effect` to properly react to `$currentBasemap` changes

## Testing

- ✅ Application works without Mapbox token
- ✅ OpenStreetMap displays correctly
- ✅ All non-Mapbox basemaps work (CyclOSM, OpenTopoMap, etc.)
- ✅ Changing between basemaps works correctly
- ✅ Mapbox basemaps automatically fallback to OpenStreetMap when no token
- ✅ With valid token, all features work as before

## Code Quality

- ✅ No code duplication
- ✅ Improved type safety
- ✅ Modern JavaScript patterns
- ✅ Clean and maintainable code
- ✅ No breaking changes

