### PR TITLE
Improve context menu performance

### DIFF
--- a/website/src/lib/components/file-list/FileList.svelte
+++ b/website/src/lib/components/file-list/FileList.svelte
@@ -2,6 +2,7 @@
     import { ScrollArea } from '$lib/components/ui/scroll-area/index';
     import * as ContextMenu from '$lib/components/ui/context-menu';
     import FileListNode from './FileListNode.svelte';
+    import FileListContextMenu from './FileListContextMenu.svelte';
     import { onMount, setContext } from 'svelte';
     import { ListFileItem, ListLevel, ListRootItem } from './file-list';
     import { ClipboardPaste, FileStack, Plus } from '@lucide/svelte';
@@ -89,3 +90,6 @@
         {/if}
     </div>
 </ScrollArea>
+
+<!-- Single shared context menu for file list items -->
+<FileListContextMenu {orientation} />

--- a/website/src/lib/components/file-list/FileListContextMenu.svelte
+++ b/website/src/lib/components/file-list/FileListContextMenu.svelte
@@ -1,0 +1,168 @@
+<script lang="ts">
+    import * as ContextMenu from '$lib/components/ui/context-menu';
+    import Shortcut from '$lib/components/Shortcut.svelte';
+    import {
+        Copy,
+        Info,
+        PaintBucket,
+        Plus,
+        Trash2,
+        Eye,
+        EyeOff,
+        ClipboardCopy,
+        ClipboardPaste,
+        Maximize,
+        Scissors,
+        FileStack,
+    } from '@lucide/svelte';
+    import { ListFileItem, ListLevel, ListTrackItem } from './file-list';
+    import { i18n } from '$lib/i18n.svelte';
+    import { editMetadata } from '$lib/components/file-list/metadata/utils.svelte';
+    import { editStyle } from '$lib/components/file-list/style/utils.svelte';
+    import { selection, copied } from '$lib/logic/selection';
+    import { fileActions, pasteSelection } from '$lib/logic/file-actions';
+    import { allHidden } from '$lib/logic/hidden';
+    import { boundsManager } from '$lib/logic/bounds';
+    import { allowedPastes } from './sortable-file-list';
+    import { fileListContextMenu } from './context-menu-state.svelte';
+
+    let {
+        orientation,
+    }: {
+        orientation: 'vertical' | 'horizontal';
+    } = $props();
+
+    // Anchor element for positioning the context menu
+    let anchorEl: HTMLDivElement;
+
+    // Reactive references to the context menu state
+    let item = $derived(fileListContextMenu.item);
+    let node = $derived(fileListContextMenu.node);
+    let menuOpen = $derived(fileListContextMenu.open);
+
+    let singleSelection = $derived($selection.size === 1);
+
+    function handleOpenChange(open: boolean) {
+        if (!open) {
+            fileListContextMenu.close();
+        }
+    }
+</script>
+
+<!-- Invisible anchor element that follows the mouse position -->
+<div
+    bind:this={anchorEl}
+    style="position: fixed; left: {fileListContextMenu.position.x}px; top: {fileListContextMenu
+        .position.y}px; width: 1px; height: 1px; pointer-events: none;"
+></div>
+
+<!-- Single shared context menu for the entire file list -->
+<ContextMenu.Root open={menuOpen} onOpenChange={handleOpenChange}>
+    <!-- Hidden trigger required by bits-ui -->
+    <ContextMenu.Trigger style="display: none; outline: none;" tabindex={-1} />
+    <ContextMenu.Content customAnchor={anchorEl} class="outline-none" preventScroll={false}>
+        {#if item !== null && node !== null}
+            {#if item instanceof ListFileItem || item instanceof ListTrackItem}
+                <ContextMenu.Item
+                    disabled={!singleSelection}
+                    onclick={() => (editMetadata.current = true)}
+                >
+                    <Info size="16" />
+                    {i18n._('menu.metadata.button')}
+                    <Shortcut key="I" ctrl={true} />
+                </ContextMenu.Item>
+                <ContextMenu.Item onclick={() => (editStyle.current = true)}>
+                    <PaintBucket size="16" />
+                    {i18n._('menu.style.button')}
+                </ContextMenu.Item>
+            {/if}
+            <ContextMenu.Item
+                onclick={() => {
+                    if ($allHidden) {
+                        fileActions.setHiddenToSelection(false);
+                    } else {
+                        fileActions.setHiddenToSelection(true);
+                    }
+                }}
+            >
+                {#if $allHidden}
+                    <Eye size="16" />
+                    {i18n._('menu.unhide')}
+                {:else}
+                    <EyeOff size="16" />
+                    {i18n._('menu.hide')}
+                {/if}
+                <Shortcut key="H" ctrl={true} />
+            </ContextMenu.Item>
+            <ContextMenu.Separator />
+            {#if orientation === 'vertical'}
+                {#if item instanceof ListFileItem}
+                    <ContextMenu.Item
+                        disabled={!singleSelection}
+                        onclick={() => fileActions.addNewTrack(item.getFileId())}
+                    >
+                        <Plus size="16" />
+                        {i18n._('menu.new_track')}
+                    </ContextMenu.Item>
+                    <ContextMenu.Separator />
+                {:else if item instanceof ListTrackItem}
+                    <ContextMenu.Item
+                        disabled={!singleSelection}
+                        onclick={() =>
+                            fileActions.addNewSegment(item.getFileId(), item.getTrackIndex())}
+                    >
+                        <Plus size="16" />
+                        {i18n._('menu.new_segment')}
+                    </ContextMenu.Item>
+                    <ContextMenu.Separator />
+                {/if}
+            {/if}
+            {#if item.level !== ListLevel.WAYPOINTS}
+                <ContextMenu.Item onclick={() => selection.selectAll()}>
+                    <FileStack size="16" />
+                    {i18n._('menu.select_all')}
+                    <Shortcut key="A" ctrl={true} />
+                </ContextMenu.Item>
+            {/if}
+            <ContextMenu.Item onclick={() => boundsManager.centerMapOnSelection()}>
+                <Maximize size="16" />
+                {i18n._('menu.center')}
+                <Shortcut key="⏎" ctrl={true} />
+            </ContextMenu.Item>
+            <ContextMenu.Separator />
+            <ContextMenu.Item onclick={fileActions.duplicateSelection}>
+                <Copy size="16" />
+                {i18n._('menu.duplicate')}
+                <Shortcut key="D" ctrl={true} />
+            </ContextMenu.Item>
+            {#if orientation === 'vertical'}
+                <ContextMenu.Item onclick={() => selection.copySelection()}>
+                    <ClipboardCopy size="16" />
+                    {i18n._('menu.copy')}
+                    <Shortcut key="C" ctrl={true} />
+                </ContextMenu.Item>
+                <ContextMenu.Item onclick={() => selection.cutSelection()}>
+                    <Scissors size="16" />
+                    {i18n._('menu.cut')}
+                    <Shortcut key="X" ctrl={true} />
+                </ContextMenu.Item>
+                <ContextMenu.Item
+                    disabled={$copied === undefined ||
+                        $copied.length === 0 ||
+                        !allowedPastes[$copied[0].level].includes(item.level)}
+                    onclick={pasteSelection}
+                >
+                    <ClipboardPaste size="16" />
+                    {i18n._('menu.paste')}
+                    <Shortcut key="V" ctrl={true} />
+                </ContextMenu.Item>
+            {/if}
+            <ContextMenu.Separator />
+            <ContextMenu.Item onclick={fileActions.deleteSelection}>
+                <Trash2 size="16" />
+                {i18n._('menu.delete')}
+                <Shortcut key="⌫" ctrl={true} />
+            </ContextMenu.Item>
+        {/if}
+    </ContextMenu.Content>
+</ContextMenu.Root>

--- a/website/src/lib/components/file-list/FileListNodeLabel.svelte
+++ b/website/src/lib/components/file-list/FileListNodeLabel.svelte
@@ -1,23 +1,6 @@
 <script lang="ts">
     import { Button } from '$lib/components/ui/button';
-    import * as ContextMenu from '$lib/components/ui/context-menu';
-    import Shortcut from '$lib/components/Shortcut.svelte';
-    import {
-        Copy,
-        Info,
-        MapPin,
-        PaintBucket,
-        Plus,
-        Trash2,
-        Waypoints,
-        Eye,
-        EyeOff,
-        ClipboardCopy,
-        ClipboardPaste,
-        Maximize,
-        Scissors,
-        FileStack,
-    } from '@lucide/svelte';
+    import { MapPin, Waypoints, EyeOff } from '@lucide/svelte';
     import {
         ListFileItem,
         ListLevel,
@@ -27,21 +10,17 @@
     } from './file-list';
     import { getContext } from 'svelte';
     import { GPXTreeElement, Track, type AnyGPXTreeElement, Waypoint, GPXFile } from 'gpx';
-    import { i18n } from '$lib/i18n.svelte';
+    import { getSymbolKey, symbols } from '$lib/assets/symbols';
+    import { selection, copied, cut } from '$lib/logic/selection';
+    import { map } from '$lib/components/map/map';
+    import { gpxLayers } from '$lib/components/map/gpx-layer/gpx-layers';
+    import { fileStateCollection } from '$lib/logic/file-state';
+    import { waypointPopup } from '$lib/components/map/gpx-layer/gpx-layer-popup';
+    import { fileListContextMenu } from './context-menu-state.svelte';
     import MetadataDialog from '$lib/components/file-list/metadata/MetadataDialog.svelte';
     import { editMetadata } from '$lib/components/file-list/metadata/utils.svelte';
     import StyleDialog from '$lib/components/file-list/style/StyleDialog.svelte';
     import { editStyle } from '$lib/components/file-list/style/utils.svelte';
-    import { getSymbolKey, symbols } from '$lib/assets/symbols';
-    import { selection, copied, cut } from '$lib/logic/selection';
-    import { map } from '$lib/components/map/map';
-    import { fileActions, pasteSelection } from '$lib/logic/file-actions';
-    import { allHidden } from '$lib/logic/hidden';
-    import { boundsManager } from '$lib/logic/bounds';
-    import { gpxLayers } from '$lib/components/map/gpx-layer/gpx-layers';
-    import { fileStateCollection } from '$lib/logic/file-state';
-    import { waypointPopup } from '$lib/components/map/gpx-layer/gpx-layer-popup';
-    import { allowedPastes } from './sortable-file-list';
 
     let {
         node,
@@ -55,8 +34,6 @@
 
     let orientation = getContext<'vertical' | 'horizontal'>('orientation');
     let embedding = getContext<boolean>('embedding');
-
-    let singleSelection = $derived($selection.size === 1);
 
     let nodeColors: string[] = $state([]);
 
@@ -97,6 +74,8 @@
 
     let symbolKey = $derived(node instanceof Waypoint ? getSymbolKey(node.sym) : undefined);
 
+    let singleSelection = $derived($selection.size === 1);
+
     let openEditMetadata: boolean = $derived(
         editMetadata.current && singleSelection && $selection.has(item)
     );
@@ -109,219 +88,114 @@
     let hidden = $derived(
         item.level === ListLevel.WAYPOINTS ? node._data.hiddenWpt : node._data.hidden
     );
+
+    function handleContextMenu(e: MouseEvent) {
+        if (embedding) {
+            e.preventDefault();
+            e.stopPropagation();
+            return;
+        }
+        if (e.ctrlKey) {
+            // Add to selection instead of opening context menu
+            e.preventDefault();
+            e.stopPropagation();
+            $selection.toggle(item);
+            $selection = $selection;
+            return;
+        }
+
+        // Prevent the default context menu
+        e.preventDefault();
+        e.stopPropagation();
+
+        // Select the item if not already selected
+        if (!$selection.has(item)) {
+            selection.selectItem(item);
+        }
+
+        // Open the shared context menu at the click position
+        fileListContextMenu.trigger(item, node, e);
+    }
 </script>
 
 <!-- svelte-ignore a11y_click_events_have_key_events -->
 <!-- svelte-ignore a11y_no_static_element_interactions -->
-<ContextMenu.Root
-    onOpenChange={(open) => {
-        if (open) {
-            if (!$selection.has(item)) {
-                selection.selectItem(item);
-            }
-        }
-    }}
->
-    <ContextMenu.Trigger class="grow truncate">
-        <Button
-            variant="ghost"
-            class="relative w-full p-0 overflow-hidden focus-visible:ring-0 focus-visible:ring-offset-0 {orientation ===
-            'vertical'
-                ? 'h-fit'
-                : 'h-9 px-1.5 shadow-md'} pointer-events-auto"
-        >
-            {#if item instanceof ListFileItem || item instanceof ListTrackItem}
-                <MetadataDialog bind:open={openEditMetadata} {node} {item} />
-                <StyleDialog bind:open={openEditStyle} {item} />
-            {/if}
-            {#if item.level === ListLevel.FILE || item.level === ListLevel.TRACK}
-                <div
-                    class="absolute {orientation === 'vertical'
-                        ? 'top-0 bottom-0 right-1 w-1'
-                        : 'top-0 h-1 left-0 right-0'}"
-                    style="background:linear-gradient(to {orientation === 'vertical'
-                        ? 'bottom'
-                        : 'right'},{nodeColors
-                        .map(
-                            (c, i) =>
-                                `${c} ${Math.floor((100 * i) / nodeColors.length)}% ${Math.floor((100 * (i + 1)) / nodeColors.length)}%`
-                        )
-                        .join(',')})"
-                ></div>
-            {/if}
-            <span
-                class="w-full text-left truncate py-1 flex flex-row items-center {hidden
-                    ? 'text-muted-foreground'
-                    : ''} {$cut && $copied?.some((i) => i.getFullId() === item.getFullId())
-                    ? 'text-muted-foreground'
-                    : ''}"
-                oncontextmenu={(e) => {
-                    if (embedding) {
-                        e.preventDefault();
-                        e.stopPropagation();
-                        return;
-                    }
-                    if (e.ctrlKey) {
-                        // Add to selection instead of opening context menu
-                        e.preventDefault();
-                        e.stopPropagation();
-                        $selection.toggle(item);
-                        $selection = $selection;
-                    }
-                }}
-                onmouseenter={() => {
-                    if (item instanceof ListWaypointItem) {
-                        let layer = gpxLayers.getLayer(item.getFileId());
-                        let file = fileStateCollection.getFile(item.getFileId());
-                        if (layer && file) {
-                            let waypoint = file.wpt[item.getWaypointIndex()];
-                            if (waypoint && !waypoint._data.hidden) {
-                                waypointPopup?.setItem({
-                                    item: waypoint,
-                                    fileId: item.getFileId(),
-                                });
-                            }
-                        }
-                    }
-                }}
-                onmouseleave={() => {
-                    if (item instanceof ListWaypointItem) {
-                        let layer = gpxLayers.getLayer(item.getFileId());
-                        if (layer) {
-                            waypointPopup?.setItem(null);
-                        }
-                    }
-                }}
-            >
-                {#if item.level === ListLevel.SEGMENT}
-                    <Waypoints size="16" class="mx-1 shrink-0" />
-                {:else if item.level === ListLevel.WAYPOINT}
-                    {#if symbolKey && symbols[symbolKey].icon}
-                        {@const SymbolIcon = symbols[symbolKey].icon}
-                        <SymbolIcon size="16" class="mx-1 shrink-0" />
-                    {:else}
-                        <MapPin size="16" class="mx-1 shrink-0" />
-                    {/if}
-                {/if}
-                <span
-                    class="grow select-none truncate {orientation === 'vertical'
-                        ? 'last:mr-2'
-                        : ''}"
-                >
-                    {label}
-                </span>
-                {#if hidden}
-                    <EyeOff
-                        size="10"
-                        class="shrink-0 size-3.5 ml-1 {orientation === 'vertical'
-                            ? 'mr-3'
-                            : 'mt-0.5'}"
-                    />
-                {/if}
-            </span>
-        </Button>
-    </ContextMenu.Trigger>
-    <ContextMenu.Content>
+<div class="grow truncate" oncontextmenu={handleContextMenu}>
+    <Button
+        variant="ghost"
+        class="relative w-full p-0 overflow-hidden focus-visible:ring-0 focus-visible:ring-offset-0 {orientation ===
+        'vertical'
+            ? 'h-fit'
+            : 'h-9 px-1.5 shadow-md'} pointer-events-auto"
+    >
         {#if item instanceof ListFileItem || item instanceof ListTrackItem}
-            <ContextMenu.Item
-                disabled={!singleSelection}
-                onclick={() => (editMetadata.current = true)}
-            >
-                <Info size="16" />
-                {i18n._('menu.metadata.button')}
-                <Shortcut key="I" ctrl={true} />
-            </ContextMenu.Item>
-            <ContextMenu.Item onclick={() => (editStyle.current = true)}>
-                <PaintBucket size="16" />
-                {i18n._('menu.style.button')}
-            </ContextMenu.Item>
+            <MetadataDialog bind:open={openEditMetadata} {node} {item} />
+            <StyleDialog bind:open={openEditStyle} {item} />
         {/if}
-        <ContextMenu.Item
-            onclick={() => {
-                if ($allHidden) {
-                    fileActions.setHiddenToSelection(false);
-                } else {
-                    fileActions.setHiddenToSelection(true);
+        {#if item.level === ListLevel.FILE || item.level === ListLevel.TRACK}
+            <div
+                class="absolute {orientation === 'vertical'
+                    ? 'top-0 bottom-0 right-1 w-1'
+                    : 'top-0 h-1 left-0 right-0'}"
+                style="background:linear-gradient(to {orientation === 'vertical'
+                    ? 'bottom'
+                    : 'right'},{nodeColors
+                    .map(
+                        (c, i) =>
+                            `${c} ${Math.floor((100 * i) / nodeColors.length)}% ${Math.floor((100 * (i + 1)) / nodeColors.length)}%`
+                    )
+                    .join(',')})"
+            ></div>
+        {/if}
+        <span
+            class="w-full text-left truncate py-1 flex flex-row items-center {hidden
+                ? 'text-muted-foreground'
+                : ''} {$cut && $copied?.some((i) => i.getFullId() === item.getFullId())
+                ? 'text-muted-foreground'
+                : ''}"
+            onmouseenter={() => {
+                if (item instanceof ListWaypointItem) {
+                    let layer = gpxLayers.getLayer(item.getFileId());
+                    let file = fileStateCollection.getFile(item.getFileId());
+                    if (layer && file) {
+                        let waypoint = file.wpt[item.getWaypointIndex()];
+                        if (waypoint && !waypoint._data.hidden) {
+                            waypointPopup?.setItem({
+                                item: waypoint,
+                                fileId: item.getFileId(),
+                            });
+                        }
+                    }
+                }
+            }}
+            onmouseleave={() => {
+                if (item instanceof ListWaypointItem) {
+                    let layer = gpxLayers.getLayer(item.getFileId());
+                    if (layer) {
+                        waypointPopup?.setItem(null);
+                    }
                 }
             }}
         >
-            {#if $allHidden}
-                <Eye size="16" />
-                {i18n._('menu.unhide')}
-            {:else}
-                <EyeOff size="16" />
-                {i18n._('menu.hide')}
+            {#if item.level === ListLevel.SEGMENT}
+                <Waypoints size="16" class="mx-1 shrink-0" />
+            {:else if item.level === ListLevel.WAYPOINT}
+                {#if symbolKey && symbols[symbolKey].icon}
+                    {@const SymbolIcon = symbols[symbolKey].icon}
+                    <SymbolIcon size="16" class="mx-1 shrink-0" />
+                {:else}
+                    <MapPin size="16" class="mx-1 shrink-0" />
+                {/if}
             {/if}
-            <Shortcut key="H" ctrl={true} />
-        </ContextMenu.Item>
-        <ContextMenu.Separator />
-        {#if orientation === 'vertical'}
-            {#if item instanceof ListFileItem}
-                <ContextMenu.Item
-                    disabled={!singleSelection}
-                    onclick={() => fileActions.addNewTrack(item.getFileId())}
-                >
-                    <Plus size="16" />
-                    {i18n._('menu.new_track')}
-                </ContextMenu.Item>
-                <ContextMenu.Separator />
-            {:else if item instanceof ListTrackItem}
-                <ContextMenu.Item
-                    disabled={!singleSelection}
-                    onclick={() =>
-                        fileActions.addNewSegment(item.getFileId(), item.getTrackIndex())}
-                >
-                    <Plus size="16" />
-                    {i18n._('menu.new_segment')}
-                </ContextMenu.Item>
-                <ContextMenu.Separator />
+            <span class="grow select-none truncate {orientation === 'vertical' ? 'last:mr-2' : ''}">
+                {label}
+            </span>
+            {#if hidden}
+                <EyeOff
+                    size="10"
+                    class="shrink-0 size-3.5 ml-1 {orientation === 'vertical' ? 'mr-3' : 'mt-0.5'}"
+                />
             {/if}
-        {/if}
-        {#if item.level !== ListLevel.WAYPOINTS}
-            <ContextMenu.Item onclick={() => selection.selectAll()}>
-                <FileStack size="16" />
-                {i18n._('menu.select_all')}
-                <Shortcut key="A" ctrl={true} />
-            </ContextMenu.Item>
-        {/if}
-        <ContextMenu.Item onclick={() => boundsManager.centerMapOnSelection()}>
-            <Maximize size="16" />
-            {i18n._('menu.center')}
-            <Shortcut key="⏎" ctrl={true} />
-        </ContextMenu.Item>
-        <ContextMenu.Separator />
-        <ContextMenu.Item onclick={fileActions.duplicateSelection}>
-            <Copy size="16" />
-            {i18n._('menu.duplicate')}
-            <Shortcut key="D" ctrl={true} />
-        </ContextMenu.Item>
-        {#if orientation === 'vertical'}
-            <ContextMenu.Item onclick={() => selection.copySelection()}>
-                <ClipboardCopy size="16" />
-                {i18n._('menu.copy')}
-                <Shortcut key="C" ctrl={true} />
-            </ContextMenu.Item>
-            <ContextMenu.Item onclick={() => selection.cutSelection()}>
-                <Scissors size="16" />
-                {i18n._('menu.cut')}
-                <Shortcut key="X" ctrl={true} />
-            </ContextMenu.Item>
-            <ContextMenu.Item
-                disabled={$copied === undefined ||
-                    $copied.length === 0 ||
-                    !allowedPastes[$copied[0].level].includes(item.level)}
-                onclick={pasteSelection}
-            >
-                <ClipboardPaste size="16" />
-                {i18n._('menu.paste')}
-                <Shortcut key="V" ctrl={true} />
-            </ContextMenu.Item>
-        {/if}
-        <ContextMenu.Separator />
-        <ContextMenu.Item onclick={fileActions.deleteSelection}>
-            <Trash2 size="16" />
-            {i18n._('menu.delete')}
-            <Shortcut key="⌫" ctrl={true} />
-        </ContextMenu.Item>
-    </ContextMenu.Content>
-</ContextMenu.Root>
+        </span>
+    </Button>
+</div>

--- a/website/src/lib/components/file-list/context-menu-state.svelte.ts
+++ b/website/src/lib/components/file-list/context-menu-state.svelte.ts
@@ -1,0 +1,35 @@
+import type { GPXTreeElement, AnyGPXTreeElement, Waypoint } from 'gpx';
+import type { ListItem } from './file-list';
+
+/**
+ * Shared state for the file list context menu.
+ * Instead of having 100+ ContextMenu.Root components, we use a single one
+ * and dynamically set the target item when right-clicking.
+ */
+class FileListContextMenuState {
+    // The item that was right-clicked
+    item: ListItem | null = $state(null);
+    // The node data for that item
+    node: GPXTreeElement<AnyGPXTreeElement> | Waypoint[] | Waypoint | null = $state(null);
+    // Position for the context menu
+    position: { x: number; y: number } = $state({ x: 0, y: 0 });
+    // Whether the menu is open
+    open: boolean = $state(false);
+
+    trigger(
+        item: ListItem,
+        node: GPXTreeElement<AnyGPXTreeElement> | Waypoint[] | Waypoint,
+        event: MouseEvent
+    ) {
+        this.item = item;
+        this.node = node;
+        this.position = { x: event.clientX, y: event.clientY };
+        this.open = true;
+    }
+
+    close() {
+        this.open = false;
+    }
+}
+
+export const fileListContextMenu = new FileListContextMenuState();


### PR DESCRIPTION
When many files are loaded and an item toward the end of the list is right-clicked, a delay occurs (around 10 seconds with 100 files) before the context menu opens. The delay is position-dependent: the context menu opens nearly instantly when right-clicking items near the beginning of the list.

## Cause

Each file list item had its own `ContextMenu.Root` component. When right-clicking, bits-ui iterates through all context menu instances to determine which one should handle the event.

## Solution

Replace per-item context menus with a single shared context menu. Native `contextmenu` events capture the click position and set the menu's `open` state. A hidden anchor element positioned at the click coordinates is used with bits-ui's `customAnchor` prop to position the menu correctly.

## Changes

- Add `context-menu-state.svelte.ts` - shared state for tracking clicked item and position
- Add `FileListContextMenu.svelte` - single shared context menu component
- Modify `FileList.svelte` - include the shared context menu
- Modify `FileListNodeLabel.svelte` - replace `ContextMenu.Root` with native `oncontextmenu` handler

## Result

Context menu now opens instantly regardless of file count or item position.