### PR TITLE
feat: allow passing a custom basePath to serve static build in subfolder

### DIFF
--- a/website/.env.example
+++ b/website/.env.example
@@ -1,1 +1,4 @@
 PUBLIC_MAPBOX_TOKEN=YOUR_MAPBOX_TOKEN
+
+# When deploying to a subdirectory, set base path here (serving on example.com/gpxstudio/ -> set BASE_PATH=/gpxstudio)
+# BASE_PATH=/gpxstudio

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -48,6 +48,7 @@
                 "@typescript-eslint/eslint-plugin": "^8.33.1",
                 "@typescript-eslint/parser": "^8.33.1",
                 "bits-ui": "^2.14.4",
+                "dotenv": "^17.2.3",
                 "eslint": "^9.28.0",
                 "eslint-config-prettier": "^10.1.5",
                 "eslint-plugin-svelte": "^3.9.1",
@@ -4185,6 +4186,19 @@
             },
             "funding": {
                 "url": "https://github.com/fb55/domutils?sponsor=1"
+            }
+        },
+        "node_modules/dotenv": {
+            "version": "17.2.3",
+            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.3.tgz",
+            "integrity": "sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://dotenvx.com"
             }
         },
         "node_modules/dunder-proto": {

--- a/website/package.json
+++ b/website/package.json
@@ -32,6 +32,7 @@
         "@typescript-eslint/eslint-plugin": "^8.33.1",
         "@typescript-eslint/parser": "^8.33.1",
         "bits-ui": "^2.14.4",
+        "dotenv": "^17.2.3",
         "eslint": "^9.28.0",
         "eslint-config-prettier": "^10.1.5",
         "eslint-plugin-svelte": "^3.9.1",

--- a/website/src/hooks.server.js
+++ b/website/src/hooks.server.js
@@ -47,7 +47,7 @@ export async function handle({ event, resolve }) {
     <meta name="twitter:site" content="@gpxstudio" />
     <meta name="twitter:creator" content="@gpxstudio" />
     <link rel="alternate" hreflang="x-default" href="https://gpx.studio${getURLForLanguage('en', path)}" />
-    <link rel="manifest" href="/${language}.manifest.webmanifest" />`;
+    <link rel="manifest" href="${base}/${language}.manifest.webmanifest" />`;
 
     if (page !== '404') {
         for (let lang of Object.keys(languages)) {

--- a/website/src/lib/scripts/pwa-manifest.ts
+++ b/website/src/lib/scripts/pwa-manifest.ts
@@ -1,5 +1,10 @@
 import fs from 'fs';
+import { config as dotenvConfig } from 'dotenv';
 import { languages } from '../languages';
+
+dotenvConfig();
+
+const basePath = process.env.BASE_PATH || '';
 
 function localizeManifest(manifestTemplateData: any, language: string) {
     const localizedManifestFile = `static/${language}.manifest.webmanifest`;
@@ -8,9 +13,9 @@ function localizeManifest(manifestTemplateData: any, language: string) {
 
     manifestTemplateData.description = localizedStrings.metadata.description;
     manifestTemplateData.lang = language;
-    manifestTemplateData.start_url = `/${language}/app`;
-    manifestTemplateData.scope = `/${language}/app`;
-    manifestTemplateData.id = `https://gpx.studio/${language}/app`;
+    manifestTemplateData.start_url = `${basePath}/${language}/app`;
+    manifestTemplateData.scope = `${basePath}/${language}/app`;
+    manifestTemplateData.id = `https://gpx.studio${basePath}/${language}/app`;
 
     fs.writeFileSync(localizedManifestFile, JSON.stringify(manifestTemplateData, null, 2));
 }

--- a/website/svelte.config.js
+++ b/website/svelte.config.js
@@ -1,6 +1,9 @@
 import adapter from '@sveltejs/adapter-static';
 import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
 import { mdsvex } from 'mdsvex';
+import { config as dotenvConfig } from 'dotenv';
+
+dotenvConfig();
 
 /** @type {import('mdsvex').MdsvexOptions} */
 const mdsvexOptions = {


### PR DESCRIPTION
Hey there!

Thank you and kudos for your incredible work here! 💪

We're gonna host a `gpx.studio` build on a subfolder `example.com/gpx.studio` folder. 

When I ran `npm run build` using a custom `BASE_PATH`, assets were still loaded on root `/`.

<img width="2994" height="910" alt="CleanShot 2025-12-30 at 15 51 22@2x" src="https://github.com/user-attachments/assets/d2e22096-1b7c-41b1-b94b-c7c49d496ddd" />

This fixes the issue:

<img width="3432" height="922" alt="CleanShot 2025-12-30 at 15 57 32@2x" src="https://github.com/user-attachments/assets/a93c4d92-201b-4d14-8371-f79b6cabbf05" />

By : 

1. Adding `dotenv` to load `.env` file at build time
2. Enabling `basePath` usage at build time


Note: I'm not sure how it can have impact for other adapters. Only tried static.

Note 2: I haven't updated the doc, how are we supposed to do it? :) 

