### PR TITLE
feat: allow using a custom brouter url

### DIFF
--- a/website/.env.example
+++ b/website/.env.example
@@ -1,1 +1,4 @@
 PUBLIC_MAPBOX_TOKEN=YOUR_MAPBOX_TOKEN
+
+# When using a custom brouter instance, set its URL here (without trailing slash)
+# PUBLIC_BROUTER_BASE_URL=https://example.com/brouter

--- a/website/src/lib/components/toolbar/tools/routing/routing.ts
+++ b/website/src/lib/components/toolbar/tools/routing/routing.ts
@@ -3,6 +3,7 @@ import { TrackPoint, distance } from 'gpx';
 import { settings } from '$lib/logic/settings';
 import { getElevation } from '$lib/utils';
 import { get } from 'svelte/store';
+import { PUBLIC_BROUTER_BASE_URL } from '$env/static/public';
 
 const { routing, routingProfile, privateRoads } = settings;
 
@@ -30,7 +31,8 @@ async function getRoute(
     brouterProfile: string,
     privateRoads: boolean
 ): Promise<TrackPoint[]> {
-    let url = `https://brouter.gpx.studio?lonlats=${points.map((point) => `${point.lon.toFixed(8)},${point.lat.toFixed(8)}`).join('|')}&profile=${brouterProfile + (privateRoads ? '-private' : '')}&format=geojson&alternativeidx=0`;
+    const brouterBaseUrl = PUBLIC_BROUTER_BASE_URL ?? 'https://brouter.gpx.studio';
+    let url = `${brouterBaseUrl}?lonlats=${points.map((point) => `${point.lon.toFixed(8)},${point.lat.toFixed(8)}`).join('|')}&profile=${brouterProfile + (privateRoads ? '-private' : '')}&format=geojson&alternativeidx=0`;
 
     let response = await fetch(url);
 


### PR DESCRIPTION
brouter URL was hardcoded, this change allows to load it from env variable

Note: same as #295, I haven't updated the doc, can do it when I know how to :) 