### PR TITLE
Add fullscreen view mode

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,12 +8,12 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
 
             - name: Install Node.js
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v6
               with:
-                  node-version: 20
+                  node-version: 24
                   cache: npm
                   cache-dependency-path: |
                       gpx/package-lock.json
@@ -41,7 +41,7 @@ jobs:
                   npm run build --prefix website
 
             - name: Upload Artifacts
-              uses: actions/upload-pages-artifact@v3
+              uses: actions/upload-pages-artifact@v4
               with:
                   path: 'website/build/'
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,12 +8,12 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
-              uses: actions/checkout@v5
+              uses: actions/checkout@v4
 
             - name: Install Node.js
-              uses: actions/setup-node@v6
+              uses: actions/setup-node@v4
               with:
-                  node-version: 24
+                  node-version: 20
                   cache: npm
                   cache-dependency-path: |
                       gpx/package-lock.json
@@ -41,7 +41,7 @@ jobs:
                   npm run build --prefix website
 
             - name: Upload Artifacts
-              uses: actions/upload-pages-artifact@v4
+              uses: actions/upload-pages-artifact@v3
               with:
                   path: 'website/build/'
 

--- a/website/src/lib/components/Menu.svelte
+++ b/website/src/lib/components/Menu.svelte
@@ -43,6 +43,7 @@
         BookOpenText,
         ChartArea,
         Maximize,
+        Maximize2,
     } from '@lucide/svelte';
     import { map } from '$lib/components/map/map';
     import { editMetadata } from '$lib/components/file-list/metadata/utils.svelte';
@@ -70,7 +71,7 @@
     import { copied, selection } from '$lib/logic/selection';
     import { allHidden } from '$lib/logic/hidden';
     import { boundsManager } from '$lib/logic/bounds';
-    import { tick } from 'svelte';
+    import { tick, onMount } from 'svelte';
     import { allowedPastes } from '$lib/components/file-list/sortable-file-list';
 
     const {
@@ -105,6 +106,23 @@
     }
 
     let layerSettingsOpen = $state(false);
+    let fullscreen = $state(false);
+
+    function toggleFullscreen() {
+        if (!document.fullscreenElement) {
+            document.documentElement.requestFullscreen?.();
+        } else {
+            document.exitFullscreen?.();
+        }
+    }
+
+    onMount(() => {
+        const handler = () => {
+            fullscreen = !!document.fullscreenElement;
+        };
+        document.addEventListener('fullscreenchange', handler);
+        return () => document.removeEventListener('fullscreenchange', handler);
+    });
 </script>
 
 <div class="absolute md:top-2 left-0 right-0 z-20 flex flex-row justify-center pointer-events-none">
@@ -377,6 +395,12 @@
                         {i18n._('menu.toggle_3d')}
                         <Shortcut key={i18n._('menu.right_click_drag')} />
                     </Menubar.Item>
+                    <Menubar.Separator />
+                    <Menubar.CheckboxItem checked={fullscreen} onCheckedChange={toggleFullscreen}>
+                        <Maximize2 size="16" />
+                        {i18n._('menu.fullscreen')}
+                        <Shortcut key="F11" />
+                    </Menubar.CheckboxItem>
                 </Menubar.Content>
             </Menubar.Menu>
             <Menubar.Menu>

--- a/website/src/lib/docs/en/menu/view.mdx
+++ b/website/src/lib/docs/en/menu/view.mdx
@@ -3,7 +3,7 @@ title: View options
 ---
 
 <script lang="ts">
-    import { ChartArea, ListTree, Map, Layers2, Coins, Milestone, Box } from '@lucide/svelte';
+    import { ChartArea, ListTree, Map, Layers2, Coins, Milestone, Box, Maximize2 } from '@lucide/svelte';
     import DocsNote from '$lib/components/docs/DocsNote.svelte';
 </script>
 
@@ -47,3 +47,8 @@ Enter or exit the 3D map view.
 To control the orientation and tilt of the map, you can also drag the map while holding <kbd>Ctrl</kbd>.
     
 </DocsNote>
+
+### <Maximize2 size="16" class="inline-block" style="margin-bottom: 2px" /> Full screen
+
+Enter or exit full screen mode.
+You can also press <kbd>F11</kbd> to toggle, or <kbd>Escape</kbd> to exit.

--- a/website/src/locales/en.json
+++ b/website/src/locales/en.json
@@ -36,6 +36,7 @@
         "switch_basemap": "Switch to previous basemap",
         "toggle_overlays": "Toggle overlays",
         "toggle_3d": "Toggle 3D",
+        "fullscreen": "Full screen",
         "settings": "Settings",
         "distance_units": "Distance units",
         "metric": "Metric",


### PR DESCRIPTION
Adds a Full screen checkbox item to the View menu (below Toggle 3D), allowing users to enter and exit full screen mode directly from the menu.

<img width="329" height="337" alt="imagen" src="https://github.com/user-attachments/assets/f655eafc-a37f-48e7-88e7-cf5fa9fde681" />
<img width="299" height="326" alt="imagen" src="https://github.com/user-attachments/assets/436db155-6776-4aed-94a0-defa5abca436" />

The implementation uses the browser Fullscreen API (requestFullscreen / exitFullscreen) and listens to the fullscreenchange event to keep the checkbox in sync with the actual state — including when the user exits full screen via Escape or the browser's native F11 shortcut.

The English documentation (menu/view.mdx) has been updated accordingly.

Closes #301 