### PR TITLE
Fix: overlays bikerouterGravel, cyclOSMlite, mapterhornHillshade, openRailwayMap cannot be toggled in Layer settings

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,12 +8,12 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
 
             - name: Install Node.js
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v6
               with:
-                  node-version: 20
+                  node-version: 24
                   cache: npm
                   cache-dependency-path: |
                       gpx/package-lock.json
@@ -41,7 +41,7 @@ jobs:
                   npm run build --prefix website
 
             - name: Upload Artifacts
-              uses: actions/upload-pages-artifact@v3
+              uses: actions/upload-pages-artifact@v4
               with:
                   path: 'website/build/'
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,12 +8,12 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
-              uses: actions/checkout@v5
+              uses: actions/checkout@v4
 
             - name: Install Node.js
-              uses: actions/setup-node@v6
+              uses: actions/setup-node@v4
               with:
-                  node-version: 24
+                  node-version: 20
                   cache: npm
                   cache-dependency-path: |
                       gpx/package-lock.json
@@ -41,7 +41,7 @@ jobs:
                   npm run build --prefix website
 
             - name: Upload Artifacts
-              uses: actions/upload-pages-artifact@v4
+              uses: actions/upload-pages-artifact@v3
               with:
                   path: 'website/build/'
 

--- a/website/src/lib/logic/settings.ts
+++ b/website/src/lib/logic/settings.ts
@@ -162,38 +162,26 @@ function getLayerValidator(allowed: Record<string, any>, fallback: string) {
 
 function filterLayerTree(t: LayerTreeType, allowed: LayerTreeType | undefined): LayerTreeType {
     const filtered: LayerTreeType = {};
-    const values = Object.values(t);
-    if (values.length == 0) return filtered;
-    if (typeof values[0] === 'boolean') {
-        if (allowed) {
-            Object.keys(allowed).forEach((key) => {
-                if (Object.hasOwn(t, key)) {
-                    filtered[key] = t[key];
-                } else {
-                    filtered[key] = allowed[key];
-                }
-            });
+    if (!allowed) return filtered;
+    Object.keys(allowed).forEach((key) => {
+        const allowedVal = allowed[key];
+        if (typeof allowedVal === 'boolean') {
+            filtered[key] = typeof t?.[key] === 'boolean' ? t[key] : allowedVal;
+        } else {
+            filtered[key] = filterLayerTree(
+                typeof t?.[key] === 'object' ? (t[key] as LayerTreeType) : {},
+                allowedVal
+            );
         }
-        Object.entries(t).forEach(([key, value]) => {
-            if (
-                !Object.hasOwn(filtered, key) &&
-                (key.startsWith('custom-') || key.startsWith('extension-'))
-            ) {
-                filtered[key] = value;
-            }
-        });
-    } else {
-        Object.entries(t).forEach(([key, value]) => {
-            if (typeof value === 'object') {
-                filtered[key] = filterLayerTree(
-                    value,
-                    typeof allowed === 'object' && typeof allowed[key] === 'object'
-                        ? allowed[key]
-                        : undefined
-                );
-            }
-        });
-    }
+    });
+    Object.entries(t ?? {}).forEach(([key, value]) => {
+        if (
+            !Object.hasOwn(filtered, key) &&
+            (key.startsWith('custom-') || key.startsWith('extension-'))
+        ) {
+            filtered[key] = value;
+        }
+    });
     return filtered;
 }
 


### PR DESCRIPTION
  In **Layer settings → Layer selection**, the following four overlay checkboxes silently do nothing — clicking them doesn't
  tick the box:

  - `bikerouterGravel` (bikerouter.de gravel)
  - `cyclOSMlite` (CyclOSM Lite)
  - `mapterhornHillshade` (Mapterhorn Hillshade)
  - `openRailwayMap` (OpenRailwayMap)

  All other overlays toggle correctly. This means the Mapterhorn hillshade overlay added in #292 is effectively unreachable
  through the UI.

This PR fixes that issue, I tested it locally and can now correctly select the mapterhorn Hillshade overlay on any base map.