### PR TITLE
add option to export GPX without elevation trackpoints

### DIFF
--- a/gpx/src/gpx.ts
+++ b/gpx/src/gpx.ts
@@ -27,6 +27,10 @@ function cloneJSON<T>(obj: T): T {
     return JSON.parse(JSON.stringify(obj));
 }
 
+function dropInterpolatedElevationTrackPoints(points: TrackPoint[]): TrackPoint[] {
+    return points.filter((p) => p._data?.anchor);
+}
+
 // An abstract class that groups functions that need to be computed recursively in the GPX file hierarchy
 export abstract class GPXTreeElement<T extends GPXTreeElement<any>> {
     _data: { [key: string]: any } = {};
@@ -1117,8 +1121,12 @@ export class TrackSegment extends GPXTreeLeaf {
     }
 
     toTrackSegmentType(exclude: string[] = []): TrackSegmentType {
+        let points = this.trkpt;
+        if (exclude.includes('ele')) {
+            points = dropInterpolatedElevationTrackPoints(points);
+        }
         return {
-            trkpt: this.trkpt.map((point) => point.toTrackPointType(exclude)),
+            trkpt: points.map((point) => point.toTrackPointType(exclude)),
         };
     }
 
@@ -1428,8 +1436,10 @@ export class TrackPoint {
     toTrackPointType(exclude: string[] = []): TrackPointType {
         let trkpt: TrackPointType = {
             attributes: this.attributes,
-            ele: this.ele,
         };
+        if (!exclude.includes('ele')) {
+            trkpt = { ...trkpt, ele: this.ele };
+        }
         if (!exclude.includes('time')) {
             trkpt = { ...trkpt, time: this.time };
         }
@@ -1563,30 +1573,22 @@ export class Waypoint {
     }
 
     toWaypointType(exclude: string[] = []): WaypointType {
-        if (!exclude.includes('time')) {
-            return {
-                attributes: this.attributes,
-                ele: this.ele,
-                time: this.time,
-                name: this.name,
-                cmt: this.cmt,
-                desc: this.desc,
-                link: this.link,
-                sym: this.sym,
-                type: this.type,
-            };
-        } else {
-            return {
-                attributes: this.attributes,
-                ele: this.ele,
-                name: this.name,
-                cmt: this.cmt,
-                desc: this.desc,
-                link: this.link,
-                sym: this.sym,
-                type: this.type,
-            };
+        const wpt: WaypointType = {
+            attributes: this.attributes,
+            name: this.name,
+            cmt: this.cmt,
+            desc: this.desc,
+            link: this.link,
+            sym: this.sym,
+            type: this.type,
+        };
+        if (!exclude.includes('ele')) {
+            wpt.ele = this.ele;
         }
+        if (!exclude.includes('time')) {
+            wpt.time = this.time;
+        }
+        return wpt;
     }
 
     clone(): Waypoint {

--- a/website/src/lib/components/export/Export.svelte
+++ b/website/src/lib/components/export/Export.svelte
@@ -16,6 +16,7 @@
         Zap,
         Earth,
         HeartPulse,
+        Mountain,
         Orbit,
         Thermometer,
         SquareActivity,
@@ -31,6 +32,7 @@
     let open = $derived(exportState.current !== ExportState.NONE);
     let exportOptions: Record<string, boolean> = $state({
         time: true,
+        ele: false,
         hr: true,
         cad: true,
         atemp: true,
@@ -41,6 +43,7 @@
         if (exportState.current === ExportState.NONE) {
             return {
                 time: false,
+                ele: false,
                 hr: false,
                 cad: false,
                 atemp: false,
@@ -61,6 +64,7 @@
             }
             return {
                 time: statistics.time.total === 0,
+                ele: statistics.elevation.gain === 0 && statistics.elevation.loss === 0,
                 hr: statistics.hr.count === 0,
                 cad: statistics.cad.count === 0,
                 atemp: statistics.atemp.count === 0,
@@ -153,6 +157,13 @@
                         <Label for="export-time" class="flex flex-row items-center gap-1">
                             <Zap size="16" />
                             {i18n._('quantities.time')}
+                        </Label>
+                    </div>
+                    <div class="flex flex-row items-center gap-1.5 {hide.ele ? 'hidden' : ''}">
+                        <Checkbox id="export-elevation" bind:checked={exportOptions.ele} />
+                        <Label for="export-elevation" class="flex flex-row items-center gap-1">
+                            <Mountain size="16" />
+                            {i18n._('quantities.elevation')}
                         </Label>
                     </div>
                     <div class="flex flex-row items-center gap-1.5 {hide.hr ? 'hidden' : ''}">


### PR DESCRIPTION
Resolves #197.

- Add a checkbox to _File > Export..._ and _Export all..._ to set if elevation data (including interpolated, fictional `<trkpt>`s) should also be exported (similar to the checkbox of time data).
- The checkbox is unselected by default.