### PR TITLE
Add Wikipedia overlay 

### DIFF
--- a/website/src/lib/assets/layers.ts
+++ b/website/src/lib/assets/layers.ts
@@ -369,6 +369,11 @@ export const basemaps: { [key: string]: string | StyleSpecification } = {
 };
 
 export const overlays: { [key: string]: string | StyleSpecification } = {
+    wiki: {
+        version: 8,
+        sources: {},
+        layers: [],
+    },
     cyclOSMlite: {
         version: 8,
         sources: {
@@ -868,6 +873,7 @@ export const overlayTree: LayerTreeType = {
             cyclOSMlite: true,
             mapterhornHillshade: true,
             openRailwayMap: true,
+            wiki: true,
         },
         countries: {
             france: {
@@ -954,6 +960,7 @@ export const defaultOverlays: LayerTreeType = {
             cyclOSMlite: false,
             mapterhornHillshade: false,
             openRailwayMap: false,
+            wiki: false,
         },
         countries: {
             france: {
@@ -1094,6 +1101,7 @@ export const defaultOverlayTree: LayerTreeType = {
             cyclOSMlite: false,
             mapterhornHillshade: false,
             openRailwayMap: false,
+            wiki: false,
         },
         countries: {
             france: {

--- a/website/src/lib/components/map/MapPopup.svelte
+++ b/website/src/lib/components/map/MapPopup.svelte
@@ -3,7 +3,9 @@
     import WaypointPopup from '$lib/components/map/gpx-layer/WaypointPopup.svelte';
     import TrackpointPopup from '$lib/components/map/gpx-layer/TrackpointPopup.svelte';
     import OverpassPopup from '$lib/components/map/layer-control/OverpassPopup.svelte';
+    import WikipediaPopup from '$lib/components/map/layer-control/WikipediaPopup.svelte';
     import type { PopupItem } from '$lib/components/map/map-popup';
+    import { WikipediaPopupArticle } from '$lib/components/map/layer-control/wikipedia-layer';
     import type { Writable } from 'svelte/store';
 
     let {
@@ -27,6 +29,8 @@
             <WaypointPopup waypoint={$item} />
         {:else if $item.item instanceof TrackPoint}
             <TrackpointPopup trackpoint={$item} />
+        {:else if $item.item instanceof WikipediaPopupArticle}
+            <WikipediaPopup article={$item} />
         {:else}
             <OverpassPopup poi={$item} />
         {/if}

--- a/website/src/lib/components/map/layer-control/LayerControl.svelte
+++ b/website/src/lib/components/map/layer-control/LayerControl.svelte
@@ -2,14 +2,17 @@
     import CustomControl from '$lib/components/map/custom-control/CustomControl.svelte';
     import LayerTree from './LayerTree.svelte';
     import { OverpassLayer } from './overpass-layer';
+    import { WikipediaLayer } from './wikipedia-layer';
     import { Separator } from '$lib/components/ui/separator';
     import { ScrollArea } from '$lib/components/ui/scroll-area/index.js';
     import { Layers } from '@lucide/svelte';
     import { settings } from '$lib/logic/settings';
     import { map } from '$lib/components/map/map';
+    import { i18n } from '$lib/i18n.svelte';
 
     let container: HTMLDivElement;
     let overpassLayer: OverpassLayer;
+    let wikipediaLayer: WikipediaLayer;
 
     const {
         currentBasemap,
@@ -25,8 +28,18 @@
         if (overpassLayer) {
             overpassLayer.remove();
         }
+        if (wikipediaLayer) {
+            wikipediaLayer.remove();
+        }
         overpassLayer = new OverpassLayer(_map, map.layerEventManager!);
+        wikipediaLayer = new WikipediaLayer(_map, map.layerEventManager!);
         overpassLayer.add();
+        wikipediaLayer.add();
+    });
+
+    $effect(() => {
+        i18n.lang;
+        wikipediaLayer?.update();
     });
 
     let open = $state(false);

--- a/website/src/lib/components/map/layer-control/WikipediaPopup.svelte
+++ b/website/src/lib/components/map/layer-control/WikipediaPopup.svelte
@@ -1,0 +1,72 @@
+<script lang="ts">
+    import * as Card from '$lib/components/ui/card';
+    import { LoaderCircle } from '@lucide/svelte';
+    import type { PopupItem } from '$lib/components/map/map-popup';
+    import type { WikipediaPopupArticle } from './wikipedia-layer';
+
+    let {
+        article,
+    }: {
+        article: PopupItem<WikipediaPopupArticle>;
+    } = $props();
+
+    let url = $derived(article.item.article_url);
+</script>
+
+<div class="block max-w-[min(22rem,75dvw)] text-card-foreground">
+    <Card.Root class="border-none shadow-md gap-0 py-0 overflow-hidden rounded-md">
+        {#if article.item.image_url}
+            <div>
+                <img
+                    src={article.item.image_url}
+                    alt={article.item.name}
+                    class="h-32 w-full object-cover"
+                    loading="lazy"
+                />
+                {#if article.item.image_license_name}
+                    <div class="px-3 py-1 text-[0.65rem] leading-tight text-muted-foreground">
+                        {#if article.item.image_license_url}
+                            <a
+                                href={article.item.image_license_url}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                class="underline"
+                                onclick={(event) => event.stopPropagation()}
+                            >
+                                {article.item.image_license_name}
+                            </a>
+                        {:else}
+                            {article.item.image_license_name}
+                        {/if}
+                    </div>
+                {/if}
+            </div>
+        {/if}
+        {#if url}
+            <a
+                href={url}
+                target="_blank"
+                rel="noopener noreferrer"
+                class="block cursor-pointer text-card-foreground no-underline"
+            >
+                <Card.Content class="flex flex-col gap-1 p-3">
+                    <Card.Title class="text-sm leading-tight">{article.item.name}</Card.Title>
+                    {#if article.item.description}
+                        <p class="text-xs leading-snug text-muted-foreground line-clamp-3">
+                            {article.item.description}
+                        </p>
+                    {/if}
+                </Card.Content>
+            </a>
+        {:else}
+            <Card.Content class="flex flex-col gap-1 p-3">
+                <Card.Title class="text-sm leading-tight">{article.item.name}</Card.Title>
+                {#if article.item.loading}
+                    <div class="flex items-center justify-center py-1 text-muted-foreground">
+                        <LoaderCircle size={12} class="animate-spin opacity-80" />
+                    </div>
+                {/if}
+            </Card.Content>
+        {/if}
+    </Card.Root>
+</div>

--- a/website/src/lib/components/map/layer-control/wikipedia-layer.ts
+++ b/website/src/lib/components/map/layer-control/wikipedia-layer.ts
@@ -1,0 +1,431 @@
+import { get } from 'svelte/store';
+import { getLayers } from './utils';
+import { i18n } from '$lib/i18n.svelte';
+import { MapPopup } from '$lib/components/map/map-popup';
+import { settings } from '$lib/logic/settings';
+import { ANCHOR_LAYER_KEY } from '$lib/components/map/style';
+import { loadSVGIcon } from '$lib/utils';
+import type { MapLayerEventManager } from '$lib/components/map/map-layer-event-manager';
+import { MapPin } from 'lucide-static';
+
+const { currentOverlays } = settings;
+
+const WIKIPEDIA_SOURCE_ID = 'wiki';
+const WIKIPEDIA_ICON_ID = 'wiki-marker-pin';
+const WIKIPEDIA_LAYER_ID = 'wiki';
+const WIKIPEDIA_LABEL_LAYER_ID = 'wiki-label';
+const WIKIPEDIA_SOURCE_LAYER = 'wiki';
+const WIKIPEDIA_ARTICLE_CACHE_LIMIT = 500;
+// TODO: change to real tile URL when available.
+const WIKIPEDIA_TILE_URL = 'http://localhost:8000/pbf/{lang}_tiles/{z}/{x}/{y}.pbf';
+
+type WikipediaTileProperties = {
+    label: string;
+    wiki_title: string;
+};
+
+export class WikipediaPopupArticle {
+    lon: number;
+    lat: number;
+    article_title: string;
+    name: string;
+    description?: string;
+    image_url?: string;
+    article_url?: string;
+    image_license_name?: string;
+    image_license_url?: string;
+    loading?: boolean;
+
+    constructor(article: WikipediaPopupArticle) {
+        this.lon = article.lon;
+        this.lat = article.lat;
+        this.article_title = article.article_title;
+        this.name = article.name;
+        Object.assign(this, article);
+    }
+}
+
+export class WikipediaLayer {
+    map: maplibregl.Map;
+    layerEventManager: MapLayerEventManager;
+    popup: MapPopup;
+    currentTileUrl: string | undefined;
+    ignoreClickUntil = 0;
+    currentArticleRequestKey: string | undefined;
+    articleCache = new Map<string, Promise<WikipediaPopupArticle>>();
+
+    unsubscribes: (() => void)[] = [];
+
+    updateBinded = this.update.bind(this);
+    onHoverBinded = this.onHover.bind(this);
+    onClickBinded = this.onClick.bind(this);
+    onTouchStartBinded = this.onTouchStart.bind(this);
+    onMouseLeaveBinded = this.onMouseLeave.bind(this);
+
+    constructor(map: maplibregl.Map, layerEventManager: MapLayerEventManager) {
+        this.map = map;
+        this.layerEventManager = layerEventManager;
+        this.popup = new MapPopup(map, {
+            closeButton: false,
+            focusAfterOpen: false,
+            maxWidth: undefined,
+            offset: 15,
+        });
+    }
+
+    add() {
+        this.map.on('style.load', this.updateBinded);
+        this.unsubscribes.push(currentOverlays.subscribe(this.updateBinded));
+        this.update();
+    }
+
+    update() {
+        try {
+            if (!this.map.getLayer(ANCHOR_LAYER_KEY.overlays)) return;
+
+            const overlays = get(currentOverlays);
+            const isWikiSelected = overlays ? getLayers(overlays).wiki === true : false;
+            if (!isWikiSelected) {
+                this.removeMapLayers();
+                this.popup.setItem(null);
+                return;
+            }
+
+            const tileUrl = WIKIPEDIA_TILE_URL.replace('{lang}', getWikiTileLanguage(i18n.lang));
+            if (this.map.getSource(WIKIPEDIA_SOURCE_ID) && this.currentTileUrl !== tileUrl) {
+                this.removeMapLayers();
+            }
+
+            if (!this.map.getSource(WIKIPEDIA_SOURCE_ID)) {
+                // Keep this dynamic because the tile path depends on the active UI language.
+                this.map.addSource(WIKIPEDIA_SOURCE_ID, {
+                    type: 'vector',
+                    tiles: [tileUrl],
+                    minzoom: 7,
+                    maxzoom: 14,
+                    attribution:
+                        '© <a href="https://www.wikipedia.org/" target="_blank">Wikipedia contributors</a> ' +
+                        '© <a href="https://www.wikidata.org/" target="_blank">Wikidata contributors</a>',
+                });
+                this.currentTileUrl = tileUrl;
+            }
+
+            this.loadIcon();
+
+            if (!this.map.getLayer(WIKIPEDIA_LAYER_ID)) {
+                this.map.addLayer(
+                    {
+                        id: WIKIPEDIA_LAYER_ID,
+                        type: 'symbol',
+                        source: WIKIPEDIA_SOURCE_ID,
+                        'source-layer': WIKIPEDIA_SOURCE_LAYER,
+                        layout: {
+                            'icon-image': WIKIPEDIA_ICON_ID,
+                            'icon-size': 0.25,
+                            'icon-padding': 0,
+                            'icon-allow-overlap': ['step', ['zoom'], false, 14, true],
+                        },
+                    },
+                    ANCHOR_LAYER_KEY.overlays
+                );
+                this.registerEvents(WIKIPEDIA_LAYER_ID);
+            }
+
+            if (!this.map.getLayer(WIKIPEDIA_LABEL_LAYER_ID)) {
+                this.map.addLayer(
+                    {
+                        id: WIKIPEDIA_LABEL_LAYER_ID,
+                        type: 'symbol',
+                        source: WIKIPEDIA_SOURCE_ID,
+                        'source-layer': WIKIPEDIA_SOURCE_LAYER,
+                        minzoom: 13,
+                        layout: {
+                            'text-field': ['get', 'label'],
+                            'text-size': 12,
+                            'text-offset': [0, 0.35],
+                            'text-anchor': 'top',
+                            'text-optional': true,
+                        },
+                        paint: {
+                            'text-color': '#1e293b',
+                            'text-halo-color': '#ffffff',
+                            'text-halo-width': 1.5,
+                        },
+                    },
+                    ANCHOR_LAYER_KEY.overlays
+                );
+            }
+        } catch (e) {
+            // No reliable way to check if the map is ready to remove sources and layers
+        }
+    }
+
+    private loadIcon() {
+        loadSVGIcon(
+            this.map,
+            WIKIPEDIA_ICON_ID,
+            `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40">
+                <circle cx="20" cy="20" r="20" fill="#0ea5e9" />
+                <g transform="translate(8 8)">
+                    ${MapPin.replace('stroke="currentColor"', 'stroke="white"')}
+                </g>
+            </svg>`
+        );
+    }
+
+    remove() {
+        this.map.off('style.load', this.updateBinded);
+        this.unsubscribes.forEach((unsubscribe) => unsubscribe());
+        this.removeMapLayers();
+        this.popup.remove();
+    }
+
+    private removeMapLayers() {
+        try {
+            this.unregisterEvents(WIKIPEDIA_LAYER_ID);
+            if (this.map.getLayer(WIKIPEDIA_LABEL_LAYER_ID)) {
+                this.map.removeLayer(WIKIPEDIA_LABEL_LAYER_ID);
+            }
+            if (this.map.getLayer(WIKIPEDIA_LAYER_ID)) {
+                this.map.removeLayer(WIKIPEDIA_LAYER_ID);
+            }
+            if (this.map.getSource(WIKIPEDIA_SOURCE_ID)) {
+                this.map.removeSource(WIKIPEDIA_SOURCE_ID);
+            }
+            this.currentTileUrl = undefined;
+        } catch (e) {
+            // No reliable way to check if the map is ready to remove sources and layers.
+        }
+    }
+
+    private registerEvents(layerId: string) {
+        this.layerEventManager.on('mouseenter', layerId, this.onHoverBinded);
+        this.layerEventManager.on('mouseleave', layerId, this.onMouseLeaveBinded);
+        this.layerEventManager.on('click', layerId, this.onClickBinded);
+        this.layerEventManager.on('touchstart', layerId, this.onTouchStartBinded);
+    }
+
+    private unregisterEvents(layerId: string) {
+        this.layerEventManager.off('mouseenter', layerId, this.onHoverBinded);
+        this.layerEventManager.off('mouseleave', layerId, this.onMouseLeaveBinded);
+        this.layerEventManager.off('click', layerId, this.onClickBinded);
+        this.layerEventManager.off('touchstart', layerId, this.onTouchStartBinded);
+    }
+
+    private onHover(e: maplibregl.MapLayerMouseEvent) {
+        this.map.getCanvas().style.cursor = 'pointer';
+        this.showPopup(e.features?.[0]);
+    }
+
+    private async onClick(e: maplibregl.MapLayerMouseEvent) {
+        if (Date.now() < this.ignoreClickUntil) return;
+        const feature = e.features?.[0];
+        if (!feature) return;
+
+        const article = createPopupArticleFromFeature(feature);
+
+        try {
+            const resolvedArticle = await this.resolveArticle(article);
+            if (resolvedArticle.article_url) {
+                window.open(resolvedArticle.article_url, '_blank', 'noopener,noreferrer');
+            }
+        } catch {
+            const fallbackUrl = getFallbackArticleUrl(article);
+            if (fallbackUrl) {
+                window.open(fallbackUrl, '_blank', 'noopener,noreferrer');
+            }
+        }
+    }
+
+    private onTouchStart(e: maplibregl.MapLayerTouchEvent) {
+        this.ignoreClickUntil = Date.now() + 500;
+        this.showPopup(e.features?.[0]);
+    }
+
+    private onMouseLeave() {
+        this.map.getCanvas().style.cursor = '';
+    }
+
+    private showPopup(feature: maplibregl.MapGeoJSONFeature | undefined) {
+        if (!feature) return;
+
+        const article = createPopupArticleFromFeature(feature);
+
+        const requestKey = getArticleRequestKey(article);
+        this.currentArticleRequestKey = requestKey;
+        this.popup.setItem({
+            item: new WikipediaPopupArticle({
+                ...article,
+                loading: true,
+            }),
+        });
+        this.resolveArticle(article)
+            .then((resolvedArticle) => {
+                // Prevent from showing other article if user
+                // moved to another marker while request was loading
+                if (this.currentArticleRequestKey !== requestKey) {
+                    return;
+                }
+
+                this.popup.setItem({
+                    item: new WikipediaPopupArticle(resolvedArticle),
+                });
+            })
+            .catch(() => {
+                if (this.currentArticleRequestKey !== requestKey) {
+                    return;
+                }
+                this.popup.setItem({
+                    item: new WikipediaPopupArticle({
+                        ...article,
+                        loading: false,
+                    }),
+                });
+            });
+    }
+
+    private resolveArticle(article: WikipediaPopupArticle) {
+        const requestKey = getArticleRequestKey(article);
+        const cachedArticle = this.articleCache.get(requestKey);
+        if (cachedArticle) {
+            this.articleCache.delete(requestKey);
+            this.articleCache.set(requestKey, cachedArticle);
+            return cachedArticle;
+        }
+
+        const articlePromise = fetchWikipediaArticle(article).catch((error) => {
+            this.articleCache.delete(requestKey);
+            throw error;
+        });
+        this.articleCache.set(requestKey, articlePromise);
+        while (this.articleCache.size > WIKIPEDIA_ARTICLE_CACHE_LIMIT) {
+            const oldestKey = this.articleCache.keys().next().value;
+            if (!oldestKey) break;
+            this.articleCache.delete(oldestKey);
+        }
+        return articlePromise;
+    }
+}
+
+function getWikiTileLanguage(lang: string) {
+    const tileLanguageOverrides: Record<string, string> = {
+        'pt-BR': 'pt',
+        'zh-HK': 'zh',
+    };
+
+    return tileLanguageOverrides[lang] ?? (lang || 'en');
+}
+
+function createPopupArticleFromFeature(
+    feature: maplibregl.MapGeoJSONFeature
+): WikipediaPopupArticle {
+    const properties = feature.properties as WikipediaTileProperties;
+    const coordinates = (feature.geometry as GeoJSON.Point).coordinates;
+
+    return new WikipediaPopupArticle({
+        lon: coordinates[0],
+        lat: coordinates[1],
+        name: properties.label,
+        article_title: properties.wiki_title,
+    });
+}
+
+function getArticleRequestKey(article: WikipediaPopupArticle) {
+    return [getWikiTileLanguage(i18n.lang), article.article_title].join(':');
+}
+
+async function fetchWikipediaArticle(
+    article: WikipediaPopupArticle
+): Promise<WikipediaPopupArticle> {
+    const lang = getWikiTileLanguage(i18n.lang);
+    const page = await fetchWikipediaPage(article, lang);
+    const imageLicense = page.pageimage
+        ? await fetchWikipediaImageLicense(page.pageimage, lang).catch(() => undefined)
+        : undefined;
+
+    return new WikipediaPopupArticle({
+        ...article,
+        name: page.title,
+        description: page.extract,
+        image_url: page.thumbnail?.source ?? page.original?.source,
+        article_url: page.fullurl ?? getWikipediaArticleUrl(lang, article.article_title),
+        image_license_name: imageLicense?.name,
+        image_license_url: imageLicense?.url,
+        loading: false,
+    });
+}
+
+async function fetchWikipediaPage(article: WikipediaPopupArticle, lang: string) {
+    const url = new URL(`https://${lang}.wikipedia.org/w/api.php`);
+    const params: Record<string, string> = {
+        action: 'query',
+        format: 'json',
+        formatversion: '2',
+        origin: '*',
+        redirects: '1',
+        prop: 'extracts|pageimages|info',
+        exintro: '1',
+        explaintext: '1',
+        inprop: 'url',
+        piprop: 'thumbnail|original|name',
+        pithumbsize: '640',
+        titles: article.article_title,
+    };
+
+    url.search = new URLSearchParams(params).toString();
+    const data = await fetchJson(url);
+    const page = data.query?.pages?.[0];
+    if (!page || page.missing) throw new Error('Wikipedia article not found');
+    return page;
+}
+
+async function fetchWikipediaImageLicense(filename: string, lang: string) {
+    const url = new URL(`https://${lang}.wikipedia.org/w/api.php`);
+    url.search = new URLSearchParams({
+        action: 'query',
+        format: 'json',
+        formatversion: '2',
+        origin: '*',
+        prop: 'imageinfo',
+        iiprop: 'extmetadata|url',
+        titles: `File:${filename}`,
+    }).toString();
+
+    const data = await fetchJson(url);
+    const metadata = data.query?.pages?.[0]?.imageinfo?.[0]?.extmetadata;
+    const name = htmlToText(metadata?.LicenseShortName?.value);
+    return {
+        name,
+        url: sanitizeHttpUrl(metadata?.LicenseUrl?.value),
+    };
+}
+
+async function fetchJson(url: URL) {
+    const response = await fetch(url);
+    if (!response.ok) throw new Error(`Wikipedia API request failed: ${response.status}`);
+    return await response.json();
+}
+
+function getFallbackArticleUrl(article: WikipediaPopupArticle) {
+    return getWikipediaArticleUrl(getWikiTileLanguage(i18n.lang), article.article_title);
+}
+
+function getWikipediaArticleUrl(lang: string, title: string | undefined) {
+    return title ? `https://${lang}.wikipedia.org/wiki/${encodeURIComponent(title)}` : undefined;
+}
+
+function sanitizeHttpUrl(value: string | undefined) {
+    // Allow only HTTP(S) URLs to prevent potential XSS
+    if (!value) return undefined;
+    try {
+        const url = new URL(value);
+        return url.protocol === 'http:' || url.protocol === 'https:' ? url.toString() : undefined;
+    } catch {
+        return undefined;
+    }
+}
+
+function htmlToText(value: string | undefined) {
+    if (!value) return undefined;
+    return new DOMParser().parseFromString(value, 'text/html').body.textContent ?? undefined;
+}

--- a/website/src/lib/components/map/layer-control/wikipedia-layer.ts
+++ b/website/src/lib/components/map/layer-control/wikipedia-layer.ts
@@ -17,7 +17,7 @@ const WIKIPEDIA_LABEL_LAYER_ID = 'wiki-label';
 const WIKIPEDIA_SOURCE_LAYER = 'wiki';
 const WIKIPEDIA_ARTICLE_CACHE_LIMIT = 500;
 // TODO: change to real tile URL when available.
-const WIKIPEDIA_TILE_URL = 'http://localhost:8000/pbf/{lang}_tiles/{z}/{x}/{y}.pbf';
+const WIKIPEDIA_TILE_URL = 'https://gpx.home.arpa/tiles/pbf/{lang}_tiles/{z}/{x}/{y}.pbf';
 
 type WikipediaTileProperties = {
     label: string;
@@ -50,7 +50,6 @@ export class WikipediaLayer {
     layerEventManager: MapLayerEventManager;
     popup: MapPopup;
     currentTileUrl: string | undefined;
-    ignoreClickUntil = 0;
     currentArticleRequestKey: string | undefined;
     articleCache = new Map<string, Promise<WikipediaPopupArticle>>();
 
@@ -58,8 +57,6 @@ export class WikipediaLayer {
 
     updateBinded = this.update.bind(this);
     onHoverBinded = this.onHover.bind(this);
-    onClickBinded = this.onClick.bind(this);
-    onTouchStartBinded = this.onTouchStart.bind(this);
     onMouseLeaveBinded = this.onMouseLeave.bind(this);
 
     constructor(map: maplibregl.Map, layerEventManager: MapLayerEventManager) {
@@ -123,7 +120,7 @@ export class WikipediaLayer {
                             'icon-image': WIKIPEDIA_ICON_ID,
                             'icon-size': 0.25,
                             'icon-padding': 0,
-                            'icon-allow-overlap': ['step', ['zoom'], false, 14, true],
+                            'icon-allow-overlap': ['step', ['zoom'], false, 13, true],
                         },
                     },
                     ANCHOR_LAYER_KEY.overlays
@@ -201,44 +198,17 @@ export class WikipediaLayer {
     private registerEvents(layerId: string) {
         this.layerEventManager.on('mouseenter', layerId, this.onHoverBinded);
         this.layerEventManager.on('mouseleave', layerId, this.onMouseLeaveBinded);
-        this.layerEventManager.on('click', layerId, this.onClickBinded);
-        this.layerEventManager.on('touchstart', layerId, this.onTouchStartBinded);
+        this.layerEventManager.on('click', layerId, this.onHoverBinded);
     }
 
     private unregisterEvents(layerId: string) {
         this.layerEventManager.off('mouseenter', layerId, this.onHoverBinded);
         this.layerEventManager.off('mouseleave', layerId, this.onMouseLeaveBinded);
-        this.layerEventManager.off('click', layerId, this.onClickBinded);
-        this.layerEventManager.off('touchstart', layerId, this.onTouchStartBinded);
+        this.layerEventManager.off('click', layerId, this.onHoverBinded);
     }
 
     private onHover(e: maplibregl.MapLayerMouseEvent) {
         this.map.getCanvas().style.cursor = 'pointer';
-        this.showPopup(e.features?.[0]);
-    }
-
-    private async onClick(e: maplibregl.MapLayerMouseEvent) {
-        if (Date.now() < this.ignoreClickUntil) return;
-        const feature = e.features?.[0];
-        if (!feature) return;
-
-        const article = createPopupArticleFromFeature(feature);
-
-        try {
-            const resolvedArticle = await this.resolveArticle(article);
-            if (resolvedArticle.article_url) {
-                window.open(resolvedArticle.article_url, '_blank', 'noopener,noreferrer');
-            }
-        } catch {
-            const fallbackUrl = getFallbackArticleUrl(article);
-            if (fallbackUrl) {
-                window.open(fallbackUrl, '_blank', 'noopener,noreferrer');
-            }
-        }
-    }
-
-    private onTouchStart(e: maplibregl.MapLayerTouchEvent) {
-        this.ignoreClickUntil = Date.now() + 500;
         this.showPopup(e.features?.[0]);
     }
 
@@ -404,10 +374,6 @@ async function fetchJson(url: URL) {
     const response = await fetch(url);
     if (!response.ok) throw new Error(`Wikipedia API request failed: ${response.status}`);
     return await response.json();
-}
-
-function getFallbackArticleUrl(article: WikipediaPopupArticle) {
-    return getWikipediaArticleUrl(getWikiTileLanguage(i18n.lang), article.article_title);
 }
 
 function getWikipediaArticleUrl(lang: string, title: string | undefined) {

--- a/website/src/locales/en.json
+++ b/website/src/locales/en.json
@@ -331,6 +331,7 @@
             "finlandTopo": "Lantmäteriverket Terrängkarta",
             "bgMountains": "BGMountains",
             "usgs": "USGS",
+            "wiki": "Wikipedia",
             "bikerouterGravel": "bikerouter.de Gravel",
             "cyclOSMlite": "CyclOSM Lite",
             "mapterhornHillshade": "Mapterhorn Hillshade",


### PR DESCRIPTION
https://github.com/gpxstudio/gpx.studio/issues/354

Generated tiles with https://github.com/dobrovolsky/wiki-tiles

Tried to implement in similar way how overpass is implemented.

It uses hybrid approach between tiles and wiki api.

I had several iteration: 
- storing all languages inside a tile
- storing all information inside a tile, but for each language separately

But I liked approach with having lightweight tiles and utilizing Wikipedia's API on demand.

So the approach is following:
- We generate small tiles contacting only 'label' (to display in pop up and high zoom) and `wiki_title` (used to loop up article via API)
- On click or hover we show pop up and go to Wikipedia's API for some details, using `wiki_title`
- There is one more request to Wikipedia's API to fetch license for a image if article has one

<details>
<summary>Small demo</summary>

https://github.com/user-attachments/assets/90732ad0-247e-4531-9e14-09b5b106e145

</details>



