### PR TITLE
Feature : Multi projects tab 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-.DS_Store
+.DS_Store.worktrees/

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -2721,9 +2721,6 @@
                 "arm"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -2741,9 +2738,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -2761,9 +2755,6 @@
                 "ppc64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -2781,9 +2772,6 @@
                 "riscv64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -2801,9 +2789,6 @@
                 "s390x"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -2821,9 +2806,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -2841,9 +2823,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -2861,9 +2840,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -2881,9 +2857,6 @@
                 "arm"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -2907,9 +2880,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -2933,9 +2903,6 @@
                 "ppc64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -2959,9 +2926,6 @@
                 "riscv64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -2985,9 +2949,6 @@
                 "s390x"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -3011,9 +2972,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -3037,9 +2995,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -3063,9 +3018,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -3482,9 +3434,6 @@
                 "arm"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3499,9 +3448,6 @@
                 "arm"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3516,9 +3462,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3533,9 +3476,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3550,9 +3490,6 @@
                 "loong64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3567,9 +3504,6 @@
                 "loong64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3584,9 +3518,6 @@
                 "ppc64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3601,9 +3532,6 @@
                 "ppc64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3618,9 +3546,6 @@
                 "riscv64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3635,9 +3560,6 @@
                 "riscv64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3652,9 +3574,6 @@
                 "s390x"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3669,9 +3588,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3686,9 +3602,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4034,9 +3947,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4054,9 +3964,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4074,9 +3981,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4094,9 +3998,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -5915,9 +5816,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -5939,9 +5837,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -5963,9 +5858,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -5987,9 +5879,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MPL-2.0",
             "optional": true,
             "os": [

--- a/website/src/lib/components/ProjectTabBar.svelte
+++ b/website/src/lib/components/ProjectTabBar.svelte
@@ -10,6 +10,7 @@
         type ProjectMeta,
     } from '$lib/logic/project-registry';
     import { switchToProject, currentDb } from '$lib/logic/active-project';
+    import { createProjectDatabase } from '$lib/db';
     import { i18n } from '$lib/i18n.svelte';
     import * as AlertDialog from '$lib/components/ui/alert-dialog';
     import * as ContextMenu from '$lib/components/ui/context-menu';
@@ -62,14 +63,24 @@
     }
 
     async function handleDeleteRequest(project: ProjectMeta) {
-        // Check if project has files
-        const db = get(currentDb);
-        if (db) {
-            const fileCount = await db.fileids.count();
-            if (fileCount > 0) {
-                deleteConfirmId = project.id;
-                return;
+        // Check if the target project (not the active one) has files
+        let fileCount = 0;
+        if (project.id === $activeProjectId) {
+            // Active project — use currentDb directly
+            const db = get(currentDb);
+            if (db) fileCount = await db.fileids.count();
+        } else {
+            // Inactive project — open its DB temporarily to check
+            const db = createProjectDatabase(project.id);
+            try {
+                fileCount = await db.fileids.count();
+            } finally {
+                db.close();
             }
+        }
+        if (fileCount > 0) {
+            deleteConfirmId = project.id;
+            return;
         }
         // No files — delete immediately
         await performDelete(project.id);
@@ -78,10 +89,12 @@
     async function performDelete(id: string) {
         const projects = $projectRegistry;
         const idx = projects.findIndex((p) => p.id === id);
-        // Switch to adjacent tab before deleting
-        const nextProject = projects[idx + 1] ?? projects[idx - 1];
-        if (nextProject) {
-            await switchToProject(nextProject.id);
+        // Only switch tabs if we're deleting the currently active project
+        if (id === $activeProjectId) {
+            const nextProject = projects[idx + 1] ?? projects[idx - 1];
+            if (nextProject) {
+                await switchToProject(nextProject.id);
+            }
         }
         await deleteProject(id);
         deleteConfirmId = null;
@@ -177,7 +190,7 @@
         </AlertDialog.Header>
         <AlertDialog.Footer>
             <AlertDialog.Cancel onclick={() => { deleteConfirmId = null; }}>
-                {i18n._('cancel')}
+                {i18n._('project.cancel')}
             </AlertDialog.Cancel>
             <AlertDialog.Action onclick={() => { if (deleteConfirmId) performDelete(deleteConfirmId); }}>
                 {i18n._('project.delete')}

--- a/website/src/lib/components/ProjectTabBar.svelte
+++ b/website/src/lib/components/ProjectTabBar.svelte
@@ -1,0 +1,187 @@
+<script lang="ts">
+    import { get } from 'svelte/store';
+    import {
+        projectRegistry,
+        activeProjectId,
+        createProject,
+        renameProject,
+        deleteProject,
+        MAX_PROJECTS,
+        type ProjectMeta,
+    } from '$lib/logic/project-registry';
+    import { switchToProject, currentDb } from '$lib/logic/active-project';
+    import { i18n } from '$lib/i18n.svelte';
+    import * as AlertDialog from '$lib/components/ui/alert-dialog';
+    import * as ContextMenu from '$lib/components/ui/context-menu';
+    import ButtonWithTooltip from '$lib/components/ButtonWithTooltip.svelte';
+    import { Plus, X, Pencil, Trash2 } from '@lucide/svelte';
+
+    // ── State ──────────────────────────────────────────────────────────────
+
+    let renamingId: string | null = $state(null);
+    let renameValue: string = $state('');
+    let deleteConfirmId: string | null = $state(null);
+    let renameInputEl: HTMLInputElement | undefined = $state(undefined);
+
+    // ── Derived ───────────────────────────────────────────────────────────
+
+    const atMax = $derived($projectRegistry.length >= MAX_PROJECTS);
+
+    // ── Handlers ──────────────────────────────────────────────────────────
+
+    async function handleTabClick(project: ProjectMeta) {
+        if (project.id !== $activeProjectId) {
+            await switchToProject(project.id);
+        }
+    }
+
+    async function handleAddProject() {
+        if (atMax) return;
+        const newId = await createProject();
+        if (newId) {
+            await switchToProject(newId);
+        }
+    }
+
+    function startRename(project: ProjectMeta) {
+        renamingId = project.id;
+        renameValue = project.name;
+        // Focus input after DOM updates
+        setTimeout(() => renameInputEl?.focus(), 0);
+    }
+
+    async function commitRename() {
+        if (renamingId && renameValue.trim()) {
+            await renameProject(renamingId, renameValue.trim());
+        }
+        renamingId = null;
+    }
+
+    function cancelRename() {
+        renamingId = null;
+    }
+
+    async function handleDeleteRequest(project: ProjectMeta) {
+        // Check if project has files
+        const db = get(currentDb);
+        if (db) {
+            const fileCount = await db.fileids.count();
+            if (fileCount > 0) {
+                deleteConfirmId = project.id;
+                return;
+            }
+        }
+        // No files — delete immediately
+        await performDelete(project.id);
+    }
+
+    async function performDelete(id: string) {
+        const projects = $projectRegistry;
+        const idx = projects.findIndex((p) => p.id === id);
+        // Switch to adjacent tab before deleting
+        const nextProject = projects[idx + 1] ?? projects[idx - 1];
+        if (nextProject) {
+            await switchToProject(nextProject.id);
+        }
+        await deleteProject(id);
+        deleteConfirmId = null;
+    }
+</script>
+
+<!-- ── Tab bar ──────────────────────────────────────────────────────────── -->
+<div class="flex items-center h-8 bg-muted/50 border-b border-border overflow-x-auto shrink-0 select-none">
+    {#each $projectRegistry as project (project.id)}
+        {@const isActive = project.id === $activeProjectId}
+        {@const isRenaming = renamingId === project.id}
+
+        <ContextMenu.Root>
+            <ContextMenu.Trigger>
+                <!-- svelte-ignore a11y_click_events_have_key_events -->
+                <!-- svelte-ignore a11y_no_static_element_interactions -->
+                <div
+                    class="group relative flex items-center gap-1 px-3 h-8 text-sm cursor-pointer shrink-0 border-r border-border transition-colors
+                        {isActive ? 'bg-background font-medium text-foreground' : 'text-muted-foreground hover:bg-background/60'}"
+                    onclick={() => handleTabClick(project)}
+                    ondblclick={() => startRename(project)}
+                >
+                    {#if isRenaming}
+                        <!-- svelte-ignore a11y_autofocus -->
+                        <input
+                            bind:this={renameInputEl}
+                            bind:value={renameValue}
+                            class="w-24 text-sm bg-transparent outline outline-1 outline-ring rounded px-1"
+                            onblur={commitRename}
+                            onkeydown={(e) => {
+                                if (e.key === 'Enter') commitRename();
+                                if (e.key === 'Escape') cancelRename();
+                                e.stopPropagation();
+                            }}
+                            onclick={(e) => e.stopPropagation()}
+                        />
+                    {:else}
+                        <span class="max-w-32 truncate">{project.name}</span>
+                    {/if}
+
+                    <!-- Close button (only shown when more than 1 project) -->
+                    {#if $projectRegistry.length > 1}
+                        <!-- svelte-ignore a11y_click_events_have_key_events -->
+                        <!-- svelte-ignore a11y_no_static_element_interactions -->
+                        <span
+                            class="ml-1 opacity-0 group-hover:opacity-100 rounded hover:bg-muted p-0.5 transition-opacity"
+                            onclick={(e) => { e.stopPropagation(); handleDeleteRequest(project); }}
+                        >
+                            <X size={12} />
+                        </span>
+                    {/if}
+                </div>
+            </ContextMenu.Trigger>
+
+            <ContextMenu.Content>
+                <ContextMenu.Item onclick={() => startRename(project)}>
+                    <Pencil size={14} class="mr-2" />
+                    {i18n._('project.rename')}
+                </ContextMenu.Item>
+                {#if $projectRegistry.length > 1}
+                    <ContextMenu.Item
+                        variant="destructive"
+                        onclick={() => handleDeleteRequest(project)}
+                    >
+                        <Trash2 size={14} class="mr-2" />
+                        {i18n._('project.delete')}
+                    </ContextMenu.Item>
+                {/if}
+            </ContextMenu.Content>
+        </ContextMenu.Root>
+    {/each}
+
+    <!-- Add project button -->
+    <ButtonWithTooltip
+        variant="ghost"
+        class="h-8 w-8 shrink-0 rounded-none"
+        label={atMax ? i18n._('project.max_reached') : i18n._('project.new')}
+        disabled={atMax}
+        onclick={atMax ? undefined : handleAddProject}
+    >
+        <Plus size={14} />
+    </ButtonWithTooltip>
+</div>
+
+<!-- ── Delete confirmation dialog ──────────────────────────────────────── -->
+<AlertDialog.Root open={deleteConfirmId !== null} onOpenChange={(open) => { if (!open) deleteConfirmId = null; }}>
+    <AlertDialog.Content>
+        <AlertDialog.Header>
+            <AlertDialog.Title>{i18n._('project.delete_confirm_title')}</AlertDialog.Title>
+            <AlertDialog.Description>
+                {i18n._('project.delete_confirm_desc')}
+            </AlertDialog.Description>
+        </AlertDialog.Header>
+        <AlertDialog.Footer>
+            <AlertDialog.Cancel onclick={() => { deleteConfirmId = null; }}>
+                {i18n._('cancel')}
+            </AlertDialog.Cancel>
+            <AlertDialog.Action onclick={() => { if (deleteConfirmId) performDelete(deleteConfirmId); }}>
+                {i18n._('project.delete')}
+            </AlertDialog.Action>
+        </AlertDialog.Footer>
+    </AlertDialog.Content>
+</AlertDialog.Root>

--- a/website/src/lib/components/map/layer-control/overpass-layer.ts
+++ b/website/src/lib/components/map/layer-control/overpass-layer.ts
@@ -5,7 +5,7 @@ import { liveQuery } from 'dexie';
 import { overpassQueryData } from '$lib/assets/layers';
 import { MapPopup } from '$lib/components/map/map-popup';
 import { settings } from '$lib/logic/settings';
-import { db } from '$lib/db';
+import { sharedDb } from '$lib/shared-db';
 import type { GeoJSONSource } from 'maplibre-gl';
 import { ANCHOR_LAYER_KEY } from '$lib/components/map/style';
 import type { MapLayerEventManager } from '$lib/components/map/map-layer-event-manager';
@@ -19,7 +19,7 @@ const mercator = new SphericalMercator({
 
 let data = writable<GeoJSON.FeatureCollection>({ type: 'FeatureCollection', features: [] });
 
-liveQuery(() => db.overpassdata.toArray()).subscribe((pois) => {
+liveQuery(() => sharedDb.overpassdata.toArray()).subscribe((pois) => {
     data.set({ type: 'FeatureCollection', features: pois.map((poi) => poi.poi) });
 });
 
@@ -165,7 +165,7 @@ export class OverpassLayer {
                     continue;
                 }
 
-                db.overpasstiles
+                sharedDb.overpasstiles
                     .where('[x+y]')
                     .equals([x, y])
                     .toArray()
@@ -247,9 +247,9 @@ export class OverpassLayer {
             }
         }
 
-        db.transaction('rw', db.overpasstiles, db.overpassdata, async () => {
-            await db.overpasstiles.bulkPut(queryTiles);
-            await db.overpassdata.bulkPut(pois);
+        sharedDb.transaction('rw', sharedDb.overpasstiles, sharedDb.overpassdata, async () => {
+            await sharedDb.overpasstiles.bulkPut(queryTiles);
+            await sharedDb.overpassdata.bulkPut(pois);
         });
 
         this.currentQueries.delete(`${x},${y}`);

--- a/website/src/lib/db.ts
+++ b/website/src/lib/db.ts
@@ -10,17 +10,9 @@ export class Database extends Dexie {
     files!: Dexie.Table<GPXFile, string>;
     patches!: Dexie.Table<{ patch: Patch[]; inversePatch: Patch[]; index: number }, number>;
     settings!: Dexie.Table<any, string>;
-    overpasstiles!: Dexie.Table<
-        { query: string; x: number; y: number; time: number },
-        [string, number, number]
-    >;
-    overpassdata!: Dexie.Table<
-        { query: string; id: number; poi: GeoJSON.Feature },
-        [string, number]
-    >;
 
-    constructor() {
-        super('Database', {
+    constructor(name: string = 'gpxstudio') {
+        super(name, {
             cache: 'immutable',
         });
         this.version(1).stores({
@@ -28,10 +20,12 @@ export class Database extends Dexie {
             files: '',
             patches: ',patch',
             settings: '',
-            overpasstiles: '[query+x+y],[x+y]',
-            overpassdata: '[query+id]',
         });
     }
 }
 
 export const db = new Database();
+
+export function createProjectDatabase(projectId: string): Database {
+    return new Database(`gpxstudio-${projectId}`);
+}

--- a/website/src/lib/logic/active-project.ts
+++ b/website/src/lib/logic/active-project.ts
@@ -1,0 +1,93 @@
+import { get, writable, type Writable } from 'svelte/store';
+import { createProjectDatabase, type Database } from '$lib/db';
+import { settings } from '$lib/logic/settings';
+import { fileStateCollection } from '$lib/logic/file-state';
+import { fileActionManager } from '$lib/logic/file-action-manager';
+import { selection } from '$lib/logic/selection';
+import { activeProjectId, touchProject } from '$lib/logic/project-registry';
+import { map } from '$lib/components/map/map';
+
+// The currently active project DB — initialized later via initializeProjects()
+export const currentDb: Writable<Database | null> = writable(null);
+
+// ── Camera persistence ─────────────────────────────────────────────────────
+
+interface CameraState {
+    center: { lng: number; lat: number };
+    zoom: number;
+    bearing: number;
+    pitch: number;
+}
+
+export async function saveMapCamera(db: Database): Promise<void> {
+    const map_ = get(map);
+    if (!map_) return;
+    const center = map_.getCenter();
+    const state: CameraState = {
+        center: { lng: center.lng, lat: center.lat },
+        zoom: map_.getZoom(),
+        bearing: map_.getBearing(),
+        pitch: map_.getPitch(),
+    };
+    await db.settings.put(state, 'mapCamera');
+}
+
+export async function restoreMapCamera(db: Database): Promise<void> {
+    const map_ = get(map);
+    if (!map_) return;
+    const state = await db.settings.get('mapCamera') as CameraState | undefined;
+    if (state) {
+        map_.jumpTo({
+            center: state.center,
+            zoom: state.zoom,
+            bearing: state.bearing,
+            pitch: state.pitch,
+        });
+    }
+}
+
+// ── Tab switching ──────────────────────────────────────────────────────────
+
+/**
+ * Switch the active project to `newProjectId`.
+ * Saves camera from old project, swaps all DB connections, restores camera for new project.
+ */
+export async function switchToProject(newProjectId: string): Promise<void> {
+    const oldDb = get(currentDb);
+
+    // 1. Save current map camera to old project DB
+    if (oldDb) {
+        await saveMapCamera(oldDb);
+    }
+
+    // 2. Disconnect all state managers from old DB
+    settings.disconnectFromDatabase();
+    fileStateCollection.disconnectFromDatabase();
+    fileActionManager.disconnectFromDatabase();
+
+    // 3. Close old DB
+    if (oldDb) {
+        oldDb.close();
+    }
+
+    // 4. Open new project DB
+    const newDb = createProjectDatabase(newProjectId);
+    currentDb.set(newDb);
+
+    // 5. Reconnect all state managers to new DB
+    settings.connectToDatabase(newDb);
+    await fileStateCollection.connectToDatabase(newDb);
+    fileActionManager.reconnectToDatabase(newDb);
+
+    // 6. Clear selection (it's ephemeral, not per-project)
+    selection.set([]);
+
+    // 7. Restore map camera for new project
+    await restoreMapCamera(newDb);
+
+    // 8. Update activeProjectId store + localStorage
+    activeProjectId.set(newProjectId);
+
+    // 9. Touch updatedAt in registry
+    await touchProject(newProjectId);
+}

--- a/website/src/lib/logic/active-project.ts
+++ b/website/src/lib/logic/active-project.ts
@@ -48,11 +48,24 @@ export async function restoreMapCamera(db: Database): Promise<void> {
 
 // ── Tab switching ──────────────────────────────────────────────────────────
 
+let _switching = false;
+
 /**
  * Switch the active project to `newProjectId`.
  * Saves camera from old project, swaps all DB connections, restores camera for new project.
+ * Re-entrant calls are ignored while a switch is in progress.
  */
 export async function switchToProject(newProjectId: string): Promise<void> {
+    if (_switching) return;
+    _switching = true;
+    try {
+        await _doSwitchToProject(newProjectId);
+    } finally {
+        _switching = false;
+    }
+}
+
+async function _doSwitchToProject(newProjectId: string): Promise<void> {
     const oldDb = get(currentDb);
 
     // 1. Save current map camera to old project DB

--- a/website/src/lib/logic/file-action-manager.ts
+++ b/website/src/lib/logic/file-action-manager.ts
@@ -25,6 +25,8 @@ export class FileActionManager {
     private _patchMaxIndex: Writable<number>;
     private _canUndo: Readable<boolean>;
     private _canRedo: Readable<boolean>;
+    private _patchIndexSub: { unsubscribe: () => void } | null = null;
+    private _patchKeysSub: { unsubscribe: () => void } | null = null;
 
     constructor(db: Database) {
         this._db = db;
@@ -62,23 +64,7 @@ export class FileActionManager {
         this._patchMinIndex = writable(0);
         this._patchMaxIndex = writable(0);
 
-        liveQuery(() => db.settings.get('patchIndex')).subscribe((value) => {
-            if (value !== undefined) {
-                this._patchIndex.set(value);
-            }
-        });
-        liveQuery(() =>
-            (db.patches.orderBy(':id').keys() as Promise<number[]>).then((keys) => {
-                if (keys.length === 0) {
-                    return { min: 0, max: 0 };
-                } else {
-                    return { min: keys[0], max: keys[keys.length - 1] + 1 };
-                }
-            })
-        ).subscribe((value) => {
-            this._patchMinIndex.set(value.min);
-            this._patchMaxIndex.set(value.max);
-        });
+        this._subscribeToDb(db);
 
         this._canUndo = derived(
             [this._patchIndex, this._patchMinIndex],
@@ -100,6 +86,43 @@ export class FileActionManager {
 
     get canRedo(): Readable<boolean> {
         return this._canRedo;
+    }
+
+    private _subscribeToDb(db: Database): void {
+        this._patchIndexSub = liveQuery(() => db.settings.get('patchIndex')).subscribe((value) => {
+            if (value !== undefined) {
+                this._patchIndex.set(value);
+            }
+        });
+        this._patchKeysSub = liveQuery(() =>
+            (db.patches.orderBy(':id').keys() as Promise<number[]>).then((keys) => {
+                if (keys.length === 0) {
+                    return { min: 0, max: 0 };
+                } else {
+                    return { min: keys[0], max: keys[keys.length - 1] + 1 };
+                }
+            })
+        ).subscribe((value) => {
+            this._patchMinIndex.set(value.min);
+            this._patchMaxIndex.set(value.max);
+        });
+    }
+
+    disconnectFromDatabase(): void {
+        this._patchIndexSub?.unsubscribe();
+        this._patchIndexSub = null;
+        this._patchKeysSub?.unsubscribe();
+        this._patchKeysSub = null;
+        // Reset patch index state
+        this._patchIndex.set(-1);
+        this._patchMinIndex.set(0);
+        this._patchMaxIndex.set(0);
+    }
+
+    reconnectToDatabase(newDb: Database): void {
+        this.disconnectFromDatabase();
+        this._db = newDb;
+        this._subscribeToDb(newDb);
     }
 
     undo() {

--- a/website/src/lib/logic/project-registry.ts
+++ b/website/src/lib/logic/project-registry.ts
@@ -1,0 +1,194 @@
+import Dexie, { liveQuery } from 'dexie';
+import { browser } from '$app/environment';
+import { get, readable, writable, type Readable, type Writable } from 'svelte/store';
+import { createProjectDatabase, type Database } from '$lib/db';
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+export interface ProjectMeta {
+    id: string;
+    name: string;
+    createdAt: number;
+    updatedAt: number;
+}
+
+// ── Registry Database ──────────────────────────────────────────────────────
+
+class RegistryDatabase extends Dexie {
+    projects!: Dexie.Table<ProjectMeta, string>;
+
+    constructor() {
+        super('gpxstudio-registry');
+        this.version(1).stores({
+            projects: 'id, name, createdAt, updatedAt',
+        });
+    }
+}
+
+export const registryDb = new RegistryDatabase();
+
+// ── Active project ID (persisted in localStorage) ─────────────────────────
+
+const ACTIVE_PROJECT_KEY = 'gpxstudio-active-project';
+
+export const activeProjectId: Writable<string> = writable(
+    browser ? (localStorage.getItem(ACTIVE_PROJECT_KEY) ?? '') : ''
+);
+
+activeProjectId.subscribe((id) => {
+    if (browser && id) {
+        localStorage.setItem(ACTIVE_PROJECT_KEY, id);
+    }
+});
+
+// ── Project registry store (liveQuery-backed) ─────────────────────────────
+
+export const projectRegistry: Readable<ProjectMeta[]> = readable<ProjectMeta[]>([], (set) => {
+    if (!browser) return;
+    const subscription = liveQuery(() =>
+        registryDb.projects.orderBy('createdAt').toArray()
+    ).subscribe((projects) => set(projects));
+    return () => subscription.unsubscribe();
+});
+
+// ── Initialization + migration ─────────────────────────────────────────────
+
+/**
+ * Called once on app startup.
+ * 1. Migrates the legacy 'Database' IndexedDB to 'gpxstudio-project-0' if it exists.
+ * 2. Ensures at least one project exists in the registry.
+ * 3. Sets activeProjectId from localStorage or defaults to the first project.
+ * Returns the Database instance for the active project.
+ */
+export async function initializeProjects(): Promise<Database> {
+    // Step 1: Migrate legacy DB if it exists
+    const legacyExists = await Dexie.exists('Database');
+    if (legacyExists) {
+        await migrateLegacyDatabase();
+    }
+
+    // Step 2: Ensure at least one project exists
+    const count = await registryDb.projects.count();
+    if (count === 0) {
+        await registryDb.projects.add({
+            id: 'project-0',
+            name: 'Project 1',
+            createdAt: Date.now(),
+            updatedAt: Date.now(),
+        });
+    }
+
+    // Step 3: Resolve active project ID
+    const allProjects = await registryDb.projects.orderBy('createdAt').toArray();
+    const storedId = browser ? localStorage.getItem(ACTIVE_PROJECT_KEY) : null;
+    const validId = allProjects.find((p) => p.id === storedId)?.id ?? allProjects[0].id;
+    activeProjectId.set(validId);
+
+    return createProjectDatabase(validId);
+}
+
+// ── Legacy migration ───────────────────────────────────────────────────────
+
+async function migrateLegacyDatabase(): Promise<void> {
+    // Open legacy DB with the original schema (version 1 only)
+    const legacyDb = new Dexie('Database');
+    legacyDb.version(1).stores({
+        fileids: ',&fileid',
+        files: '',
+        patches: ',patch',
+        settings: '',
+        overpasstiles: '[query+x+y],[x+y]',
+        overpassdata: '[query+id]',
+    });
+
+    try {
+        await legacyDb.open();
+
+        // Create the target project-0 DB
+        const targetDb = createProjectDatabase('project-0');
+        await targetDb.open();
+
+        // Copy fileids
+        const fileids = await (legacyDb as any).table('fileids').toArray();
+        if (fileids.length > 0) {
+            await targetDb.fileids.bulkPut(fileids);
+        }
+
+        // Copy files
+        const files = await (legacyDb as any).table('files').toArray();
+        if (files.length > 0) {
+            await targetDb.files.bulkPut(files);
+        }
+
+        // Copy patches
+        const patches = await (legacyDb as any).table('patches').toArray();
+        if (patches.length > 0) {
+            await targetDb.patches.bulkPut(patches);
+        }
+
+        // Copy settings
+        const settings = await (legacyDb as any).table('settings').toArray();
+        if (settings.length > 0) {
+            await targetDb.settings.bulkPut(settings);
+        }
+
+        await targetDb.close();
+        legacyDb.close();
+
+        // Register project-0 in registry
+        await registryDb.projects.put({
+            id: 'project-0',
+            name: 'Project 1',
+            createdAt: Date.now(),
+            updatedAt: Date.now(),
+        });
+
+        // Delete the legacy DB
+        await Dexie.delete('Database');
+    } catch (err) {
+        console.error('Migration from legacy database failed:', err);
+        legacyDb.close();
+    }
+}
+
+// ── Project CRUD ───────────────────────────────────────────────────────────
+
+const MAX_PROJECTS = 10;
+
+export async function createProject(): Promise<string | null> {
+    const count = await registryDb.projects.count();
+    if (count >= MAX_PROJECTS) return null;
+
+    // Find next available project index
+    const allProjects = await registryDb.projects.toArray();
+    const existingIds = new Set(allProjects.map((p) => p.id));
+    let index = 0;
+    while (existingIds.has(`project-${index}`)) index++;
+
+    const id = `project-${index}`;
+    const projectNumber = count + 1;
+
+    await registryDb.projects.add({
+        id,
+        name: `Project ${projectNumber}`,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+    });
+
+    return id;
+}
+
+export async function renameProject(id: string, name: string): Promise<void> {
+    await registryDb.projects.update(id, { name: name.trim() || 'Unnamed Project', updatedAt: Date.now() });
+}
+
+export async function deleteProject(id: string): Promise<void> {
+    await registryDb.projects.delete(id);
+    await Dexie.delete(`gpxstudio-${id}`);
+}
+
+export async function touchProject(id: string): Promise<void> {
+    await registryDb.projects.update(id, { updatedAt: Date.now() });
+}
+
+export { MAX_PROJECTS };

--- a/website/src/lib/shared-db.ts
+++ b/website/src/lib/shared-db.ts
@@ -1,0 +1,24 @@
+import Dexie from 'dexie';
+
+export class SharedDatabase extends Dexie {
+    overpasstiles!: Dexie.Table<
+        { query: string; x: number; y: number; time: number },
+        [string, number, number]
+    >;
+    overpassdata!: Dexie.Table<
+        { query: string; id: number; poi: GeoJSON.Feature },
+        [string, number]
+    >;
+
+    constructor() {
+        super('gpxstudio-shared', {
+            cache: 'immutable',
+        });
+        this.version(1).stores({
+            overpasstiles: '[query+x+y],[x+y]',
+            overpassdata: '[query+id]',
+        });
+    }
+}
+
+export const sharedDb = new SharedDatabase();

--- a/website/src/locales/en.json
+++ b/website/src/locales/en.json
@@ -556,5 +556,14 @@
     },
     "webgl2_required": "WebGL 2 is required to display the map.",
     "enable_webgl2": "Learn how to enable WebGL 2 in your browser",
-    "page_not_found": "page not found"
+    "page_not_found": "page not found",
+    "project": {
+        "new": "New project",
+        "rename": "Rename",
+        "delete": "Delete project",
+        "delete_confirm_title": "Delete this project?",
+        "delete_confirm_desc": "This project contains files. Deleting it will permanently remove all its data. This cannot be undone.",
+        "max_reached": "Maximum number of projects reached (10)",
+        "cancel": "Cancel"
+    }
 }

--- a/website/src/routes/[[language]]/app/+page.svelte
+++ b/website/src/routes/[[language]]/app/+page.svelte
@@ -18,8 +18,11 @@
     import { page } from '$app/state';
     import { gpxStatistics, hoveredPoint, slicedGPXStatistics } from '$lib/logic/statistics';
     import { getURLForGoogleDriveFile } from '$lib/components/embedding/embedding';
-    import { db } from '$lib/db';
     import { fileStateCollection } from '$lib/logic/file-state';
+    import { initializeProjects } from '$lib/logic/project-registry';
+    import { currentDb, saveMapCamera } from '$lib/logic/active-project';
+    import ProjectTabBar from '$lib/components/ProjectTabBar.svelte';
+    import { get } from 'svelte/store';
 
     const {
         treeFileView,
@@ -36,30 +39,40 @@
     );
 
     onMount(async () => {
-        settings.connectToDatabase(db);
-        fileStateCollection.connectToDatabase(db).then(() => {
-            let files: string[] = JSON.parse(page.url.searchParams.get('files') || '[]');
-            let ids: string[] = JSON.parse(page.url.searchParams.get('ids') || '[]');
-            let urls: string[] = files.concat(ids.map(getURLForGoogleDriveFile));
+        // Initialize project registry (handles migration from legacy DB)
+        const activeDb = await initializeProjects();
+        currentDb.set(activeDb);
 
-            if (urls.length > 0) {
-                let downloads: Promise<File | null>[] = [];
-                urls.forEach((url) => {
-                    downloads.push(
-                        fetch(url)
-                            .then((response) => response.blob())
-                            .then((blob) => new File([blob], url.split('/').pop() ?? ''))
-                    );
-                });
+        settings.connectToDatabase(activeDb);
+        await fileStateCollection.connectToDatabase(activeDb);
 
-                Promise.all(downloads).then((files) => {
-                    loadFiles(files.filter((file) => file !== null));
-                });
-            }
-        });
+        // Load files from URL params after DB is ready
+        let files: string[] = JSON.parse(page.url.searchParams.get('files') || '[]');
+        let ids: string[] = JSON.parse(page.url.searchParams.get('ids') || '[]');
+        let urls: string[] = files.concat(ids.map(getURLForGoogleDriveFile));
+
+        if (urls.length > 0) {
+            let downloads: Promise<File | null>[] = [];
+            urls.forEach((url) => {
+                downloads.push(
+                    fetch(url)
+                        .then((response) => response.blob())
+                        .then((blob) => new File([blob], url.split('/').pop() ?? ''))
+                );
+            });
+
+            Promise.all(downloads).then((downloadedFiles) => {
+                loadFiles(downloadedFiles.filter((file) => file !== null));
+            });
+        }
     });
 
-    onDestroy(() => {
+    onDestroy(async () => {
+        // Save camera position before leaving
+        const db = get(currentDb);
+        if (db) {
+            await saveMapCamera(db);
+        }
         settings.disconnectFromDatabase();
         fileStateCollection.disconnectFromDatabase();
     });
@@ -104,6 +117,7 @@
 
 <div class="fixed flex flex-row w-dvw h-dvh">
     <div class="flex flex-col grow h-full min-w-0">
+        <ProjectTabBar />
         <div class="grow relative">
             <Menu />
             <div
@@ -111,7 +125,7 @@
             >
                 <Toolbar />
             </div>
-            <Map class="h-full {$treeFileView ? '' : 'horizontal'}" />
+            <Map class="h-full {$treeFileView ? '' : 'horizontal'}" hash={false} />
             <StreetViewControl />
             <LayerControl />
             <GPXLayers />

--- a/website/src/routes/[[language]]/app/+page.svelte
+++ b/website/src/routes/[[language]]/app/+page.svelte
@@ -21,6 +21,7 @@
     import { fileStateCollection } from '$lib/logic/file-state';
     import { initializeProjects } from '$lib/logic/project-registry';
     import { currentDb, saveMapCamera } from '$lib/logic/active-project';
+    import { fileActionManager } from '$lib/logic/file-action-manager';
     import ProjectTabBar from '$lib/components/ProjectTabBar.svelte';
     import { get } from 'svelte/store';
 
@@ -45,6 +46,7 @@
 
         settings.connectToDatabase(activeDb);
         await fileStateCollection.connectToDatabase(activeDb);
+        fileActionManager.reconnectToDatabase(activeDb);
 
         // Load files from URL params after DB is ready
         let files: string[] = JSON.parse(page.url.searchParams.get('files') || '[]');
@@ -75,6 +77,7 @@
         }
         settings.disconnectFromDatabase();
         fileStateCollection.disconnectFromDatabase();
+        fileActionManager.disconnectFromDatabase();
     });
 </script>
 


### PR DESCRIPTION
## Summary

- Each project gets its own isolated Dexie IndexedDB (`gpxstudio-{projectId}`)
- A registry DB (`gpxstudio-registry`) stores project metadata (name, createdAt, updatedAt)
- Shared overpass tile cache extracted to a dedicated `gpxstudio-shared` DB (preserved across projects)
- Tab bar above the menu: create, rename (double-click or right-click), delete (with confirmation if project has files), switch — max 10 projects
- Map camera position (center, zoom, bearing, pitch) saved per-project and restored on tab switch
- One-time migration from the legacy `Database` IndexedDB to `gpxstudio-project-0` on first run
- `FileActionManager` gains `reconnectToDatabase()` / `disconnectFromDatabase()` for clean DB swapping

## Test plan

- [ ] App loads with "Project 1" tab and existing files visible
- [ ] Click `+` → "Project 2" created, empty file list
- [ ] Add a GPX to Project 2, switch to Project 1 → file not visible
- [ ] Switch back to Project 2 → file still there
- [ ] Undo/redo history is independent per project
- [ ] Map camera restores per-project on tab switch
- [ ] Double-click tab → inline rename, persists on reload
- [ ] Right-click tab → Rename / Delete context menu
- [ ] Delete tab with files → confirmation dialog appears
- [ ] Delete tab without files → immediate, no dialog
- [ ] Deleting an inactive tab does not switch active tab
- [ ] Overpass POI cache shared across tabs (no re-fetch on switch)
- [ ] Existing users: data migrated from old DB automatically