### PR TITLE
feat: Map Matching

### DIFF
--- a/website/src/lib/components/toolbar/Toolbar.svelte
+++ b/website/src/lib/components/toolbar/Toolbar.svelte
@@ -12,6 +12,7 @@
         Funnel,
         Scissors,
         MountainSnow,
+        Magnet,
     } from '@lucide/svelte';
     import { i18n } from '$lib/i18n.svelte';
 
@@ -51,6 +52,9 @@
         </ToolbarItem>
         <ToolbarItem itemTool={Tool.CLEAN} label={i18n._('toolbar.clean.tooltip')}>
             <SquareDashedMousePointer size="18" class="size-4.5" />
+        </ToolbarItem>
+        <ToolbarItem itemTool={Tool.MAP_MATCHING} label={i18n._('toolbar.map_matching.tooltip')}>
+            <Magnet size="18" class="size-4.5" />
         </ToolbarItem>
     </div>
     <ToolbarItemMenu class={props.class ?? ''} />

--- a/website/src/lib/components/toolbar/ToolbarItemMenu.svelte
+++ b/website/src/lib/components/toolbar/ToolbarItemMenu.svelte
@@ -10,6 +10,7 @@
     import Extract from '$lib/components/toolbar/tools/Extract.svelte';
     import Clean from '$lib/components/toolbar/tools/Clean.svelte';
     import Reduce from '$lib/components/toolbar/tools/reduce/Reduce.svelte';
+    import MapMatching from '$lib/components/toolbar/tools/MapMatching.svelte';
     import RoutingControlPopup from '$lib/components/toolbar/tools/routing/RoutingControlPopup.svelte';
     import maplibregl from 'maplibre-gl';
     import { settings } from '$lib/logic/settings';
@@ -62,6 +63,8 @@
                         <Clean />
                     {:else if $currentTool === Tool.REDUCE}
                         <Reduce />
+                    {:else if $currentTool === Tool.MAP_MATCHING}
+                        <MapMatching />
                     {/if}
                 </Card.Content>
             </Card.Root>

--- a/website/src/lib/components/toolbar/tools.ts
+++ b/website/src/lib/components/toolbar/tools.ts
@@ -10,6 +10,7 @@ export enum Tool {
     ELEVATION,
     REDUCE,
     CLEAN,
+    MAP_MATCHING,
 }
 
 export const currentTool: Writable<Tool | null> = writable(null);

--- a/website/src/lib/components/toolbar/tools/MapMatching.svelte
+++ b/website/src/lib/components/toolbar/tools/MapMatching.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+    import { Button } from '$lib/components/ui/button';
+    import Help from '$lib/components/Help.svelte';
+    import { i18n } from '$lib/i18n.svelte';
+    import { getURLForLanguage } from '$lib/utils';
+    import { Magnet } from '@lucide/svelte';
+    import { selection } from '$lib/logic/selection';
+    import { fileActions } from '$lib/logic/file-actions';
+
+    let props: { class?: string } = $props();
+
+    let validSelection = $derived($selection.size > 0);
+</script>
+
+<div class="flex flex-col gap-3 w-full max-w-80 {props.class ?? ''}">
+    <Button
+        variant="outline"
+        class="whitespace-normal h-fit min-h-8 py-1"
+        disabled={!validSelection}
+        onclick={() => fileActions.mapMatch()}
+    >
+        <Magnet size="16" class="shrink-0" />
+        {i18n._('toolbar.map_matching.button')}
+    </Button>
+    <Help link={getURLForLanguage(i18n.lang, '/help/toolbar/elevation')}>
+        {#if validSelection}
+            {i18n._('toolbar.map_matching.help')}
+        {:else}
+            {i18n._('toolbar.map_matching.help_no_selection')}
+        {/if}
+    </Help>
+</div>

--- a/website/src/lib/logic/file-actions.ts
+++ b/website/src/lib/logic/file-actions.ts
@@ -3,6 +3,7 @@ import { fileActionManager } from '$lib/logic/file-action-manager';
 import { applyToOrderedItemsFromFile, copied, cut, selection } from '$lib/logic/selection';
 import { currentTool, Tool } from '$lib/components/toolbar/tools';
 import { SplitType } from '$lib/components/toolbar/tools/scissors/scissors';
+import { routingProfiles } from '$lib/components/toolbar/tools/routing/routing';
 import {
     ListFileItem,
     ListLevel,
@@ -675,6 +676,119 @@ export const fileActions = {
                     }
                 }
             });
+        });
+    },
+    mapMatch: async () => {
+        if (get(selection).size === 0) return;
+
+        // Collect track points per segment for all selected items
+        const segmentPoints = new Map<ListTrackSegmentItem, TrackPoint[]>();
+
+        selection.applyToOrderedSelectedItemsFromFile((fileId, level, items) => {
+            const file = fileStateCollection.getFile(fileId);
+            if (!file) return;
+
+            const addSegment = (trackIndex: number, segmentIndex: number) =>
+                segmentPoints.set(new ListTrackSegmentItem(fileId, trackIndex, segmentIndex), [
+                    ...file.trk[trackIndex].trkseg[segmentIndex].trkpt,
+                ]);
+
+            if (level === ListLevel.FILE) {
+                // All segments in all tracks in file
+                file.trk.forEach((track, ti) =>
+                    track.trkseg.forEach((_, si) => addSegment(ti, si))
+                );
+            } else if (level === ListLevel.TRACK) {
+                // All segments in selected tracks
+                items.forEach((item) => {
+                    const ti = (item as ListTrackItem).getTrackIndex();
+                    file.trk[ti].trkseg.forEach((_, si) => addSegment(ti, si));
+                });
+            } else if (level === ListLevel.SEGMENT) {
+                // Only selected segments
+                items.forEach((item) => {
+                    const ti = (item as ListTrackSegmentItem).getTrackIndex();
+                    const si = (item as ListTrackSegmentItem).getSegmentIndex();
+                    addSegment(ti, si);
+                });
+            }
+        });
+
+        if (segmentPoints.size === 0) return;
+
+        // Resolve the GraphHopper profile from the current routing selection.
+        // Fall back to 'bike' for BRouter-based profiles (e.g. water, railway)
+        // which have no equivalent map matching profile.
+        const profileKey = get(settings.routingProfile);
+        const profileDef = routingProfiles[profileKey];
+        const ghProfile = profileDef?.engine === 'graphhopper' ? profileDef.profile : 'bike';
+
+        // Wrap points in a minimal GPX envelope for the /match endpoint
+        const buildGPX = (points: TrackPoint[]) => {
+            const trkpts = points
+                .map(
+                    (p) => `    <trkpt lat="${p.attributes.lat}" lon="${p.attributes.lon}"></trkpt>`
+                )
+                .join('\n');
+            return `<?xml version="1.0" encoding="UTF-8"?>\n<gpx version="1.1" creator="gpx.studio">\n  <trk><trkseg>\n${trkpts}\n  </trkseg></trk>\n</gpx>`;
+        };
+
+        // Match all segments in parallel. Segments that fail (no road nearby,
+        // outside covered area, etc.) are silently kept as-is.
+        const matchedPoints = new Map<ListTrackSegmentItem, TrackPoint[]>();
+
+        await Promise.all(
+            Array.from(segmentPoints.entries()).map(async ([item, points]) => {
+                try {
+                    const response = await fetch(
+                        `/graphhopper/match?profile=${ghProfile}&points_encoded=false&gps_accuracy=40`,
+                        {
+                            method: 'POST',
+                            headers: { 'Content-Type': 'application/gpx+xml' },
+                            body: buildGPX(points),
+                        }
+                    );
+
+                    const json = response.ok ? await response.json() : null;
+                    const coordinates: [number, number, number?][] | undefined =
+                        json?.paths?.[0]?.points?.coordinates;
+
+                    // Use matched coordinates if available, otherwise keep original points
+                    matchedPoints.set(
+                        item,
+                        coordinates
+                            ? coordinates.map(
+                                  ([lon, lat, ele]) =>
+                                      new TrackPoint({
+                                          attributes: { lat, lon },
+                                          ele: ele ?? 0,
+                                          extensions: {},
+                                      })
+                              )
+                            : points
+                    );
+                } catch {
+                    // Network error or unexpected response — keep original points
+                    matchedPoints.set(item, points);
+                }
+            })
+        );
+
+        // Apply all segment replacements as a single action
+        fileActionManager.applyGlobal((draft) => {
+            for (const [item, matched] of matchedPoints) {
+                const file = draft.get(item.getFileId());
+                if (!file) continue;
+                const ti = item.getTrackIndex();
+                const si = item.getSegmentIndex();
+                file.replaceTrackPoints(
+                    ti,
+                    si,
+                    0,
+                    file.trk[ti].trkseg[si].getNumberOfTrackPoints() - 1,
+                    matched
+                );
+            }
         });
     },
     addOrUpdateWaypoint: (waypoint: WaypointType, item?: ListWaypointItem) => {

--- a/website/src/lib/logic/file-actions.ts
+++ b/website/src/lib/logic/file-actions.ts
@@ -33,6 +33,7 @@ import { settings } from '$lib/logic/settings';
 import { getClosestLinePoint, getClosestTrackSegments, getElevation } from '$lib/utils';
 import { gpxStatistics } from '$lib/logic/statistics';
 import { boundsManager } from './bounds';
+import { toast } from 'svelte-sonner';
 
 // Generate unique file ids, different from the ones in the database
 export function getFileIds(n: number) {
@@ -723,6 +724,14 @@ export const fileActions = {
         const profileDef = routingProfiles[profileKey];
         const ghProfile = profileDef?.engine === 'graphhopper' ? profileDef.profile : 'bike';
 
+        // GraphHopper's matcher searches for candidate roads within roughly
+        // 2x this radius (meters) of each point, and treats it as the Gaussian
+        // sigma of GPS noise when scoring candidates.
+        const gpsAccuracy = 20;
+        // A matched point further than this from the original is treated as a
+        // snap to the wrong road rather than noise correction (3 sigma).
+        const confidenceThreshold = Math.max(3 * gpsAccuracy, 50);
+
         // Wrap points in a minimal GPX envelope for the /match endpoint
         const buildGPX = (points: TrackPoint[]) => {
             const trkpts = points
@@ -733,15 +742,24 @@ export const fileActions = {
             return `<?xml version="1.0" encoding="UTF-8"?>\n<gpx version="1.1" creator="gpx.studio">\n  <trk><trkseg>\n${trkpts}\n  </trkseg></trk>\n</gpx>`;
         };
 
-        // Match all segments in parallel. Segments that fail (no road nearby,
-        // outside covered area, etc.) are silently kept as-is.
+        // Match all segments in parallel. Segments that fail or come back
+        // with a low-confidence match are kept as-is, and reported below.
         const matchedPoints = new Map<ListTrackSegmentItem, TrackPoint[]>();
+        let hasTooFewPoints = false;
+        let hasRequestFailure = false;
+        let hasLowConfidence = false;
 
         await Promise.all(
             Array.from(segmentPoints.entries()).map(async ([item, points]) => {
+                if (points.length < 2) {
+                    hasTooFewPoints = true;
+                    matchedPoints.set(item, points);
+                    return;
+                }
+
                 try {
                     const response = await fetch(
-                        `/graphhopper/match?profile=${ghProfile}&points_encoded=false&gps_accuracy=40`,
+                        `https://graphhopper.gpx.studio/match?profile=${ghProfile}&points_encoded=false&elevation=true&gps_accuracy=${gpsAccuracy}&max_visited_nodes=10000`,
                         {
                             method: 'POST',
                             headers: { 'Content-Type': 'application/gpx+xml' },
@@ -749,32 +767,67 @@ export const fileActions = {
                         }
                     );
 
-                    const json = response.ok ? await response.json() : null;
+                    if (!response.ok) {
+                        hasRequestFailure = true;
+                        matchedPoints.set(item, points);
+                        return;
+                    }
+
+                    const json = await response.json();
                     const coordinates: [number, number, number?][] | undefined =
                         json?.paths?.[0]?.points?.coordinates;
 
-                    // Use matched coordinates if available, otherwise keep original points
-                    matchedPoints.set(
-                        item,
-                        coordinates
-                            ? coordinates.map(
-                                  ([lon, lat, ele]) =>
-                                      new TrackPoint({
-                                          attributes: { lat, lon },
-                                          ele: ele ?? 0,
-                                          extensions: {},
-                                      })
-                              )
-                            : points
-                    );
+                    if (!coordinates || coordinates.length === 0) {
+                        hasRequestFailure = true;
+                        matchedPoints.set(item, points);
+                        return;
+                    }
+
+                    const matched: TrackPoint[] = [];
+                    for (let i = 0; i < coordinates.length; i++) {
+                        matched.push(
+                            new TrackPoint({
+                                attributes: { lat: coordinates[i][1], lon: coordinates[i][0] },
+                                ele: coordinates[i][2] ?? (i > 0 ? matched[i - 1].ele : 0),
+                                extensions: {},
+                            })
+                        );
+                    }
+
+                    // Reject the match for this segment if any original point
+                    // ended up far from the resulting line — a sign it snapped
+                    // to the wrong road among several nearby candidates.
+                    const isLowConfidence = points.some((point) => {
+                        const details: { distance?: number } = {};
+                        getClosestLinePoint(matched, point, details);
+                        return (details.distance ?? Number.MAX_VALUE) > confidenceThreshold;
+                    });
+
+                    if (isLowConfidence) {
+                        hasLowConfidence = true;
+                        matchedPoints.set(item, points);
+                    } else {
+                        matchedPoints.set(item, matched);
+                    }
                 } catch {
                     // Network error or unexpected response — keep original points
+                    hasRequestFailure = true;
                     matchedPoints.set(item, points);
                 }
             })
         );
 
-        // Apply all segment replacements as a single action
+        if (hasTooFewPoints) toast.error(i18n._('toolbar.map_matching.error_too_few_points'));
+        if (hasRequestFailure) toast.error(i18n._('toolbar.map_matching.error'));
+        if (hasLowConfidence) toast.error(i18n._('toolbar.map_matching.error_low_confidence'));
+
+        // Apply all segment replacements as a single action, skipping entirely
+        // if every segment was kept as-is (nothing to undo)
+        const anyChanged = Array.from(matchedPoints.entries()).some(
+            ([item, matched]) => matched !== segmentPoints.get(item)
+        );
+        if (!anyChanged) return;
+
         fileActionManager.applyGlobal((draft) => {
             for (const [item, matched] of matchedPoints) {
                 const file = draft.get(item.getFileId());

--- a/website/src/locales/en.json
+++ b/website/src/locales/en.json
@@ -266,6 +266,14 @@
             "button": "Delete",
             "help": "Select a rectangle area on the map to remove GPS points and points of interest.",
             "help_no_selection": "Select a trace to clean GPS points and points of interest."
+        },
+        "map_matching": {
+            "tooltip": "Snap every point to the nearest road",
+            "button": "Snap to roads",
+            "help": "Snap the selected track to the road network.",
+            "help_no_selection": "Select a track or segment to snap to roads.",
+            "error": "Map matching failed.",
+            "error_too_few_points": "Not enough points to match."
         }
     },
     "layers": {

--- a/website/src/locales/en.json
+++ b/website/src/locales/en.json
@@ -273,7 +273,8 @@
             "help": "Snap the selected track to the road network.",
             "help_no_selection": "Select a track or segment to snap to roads.",
             "error": "Map matching failed.",
-            "error_too_few_points": "Not enough points to match."
+            "error_too_few_points": "Not enough points to match.",
+            "error_low_confidence": "Some segments were kept unchanged because the match was too uncertain (multiple nearby roads)."
         }
     },
     "layers": {


### PR DESCRIPTION
# Context
After recording activities and exporting their GPX files, depending on speed / accuracy, the tracks aren't clean.
e.g:
<img width="446" height="399" alt="image" src="https://github.com/user-attachments/assets/f10749db-4b2b-4a70-a2c6-46277e2de0eb" />

and : https://github.com/gpxstudio/gpx.studio/issues/199

# Objective
Using GraphHopper's `/match` API, snap the selected track(s) to the road/path network.

### Expected behavior on short route
<img width="446" height="399" alt="image" src="https://github.com/user-attachments/assets/ec30a6cb-74cd-441f-a425-d0789451d175" />
<img width="446" height="399" alt="image" src="https://github.com/user-attachments/assets/8d5f41cd-cba3-4682-90b1-cc0cc547baf6" />

[short_routes.zip (raw and matched route files)](https://github.com/user-attachments/files/29542036/short_routes.zip)

### Expected behavior on longer route
[longer_routes.zip (raw and matched route files)](https://github.com/user-attachments/files/29541974/longer_routes.zip)

### Known limitation: extreme manual/off-road input
An earlier version of this PR was "aggressive": it would silently apply whatever GraphHopper returned, even when the result was clearly wrong (snapped to a distant, unrelated road). I dug into this with a deliberately extreme test case: a route hand-drawn across open fields with routing off (so no real road underneath at all).

Turns out GraphHopper's `/match` uses an HMM/Viterbi algorithm (Newson & Krumm) designed to correct GPS *noise* around a path that's already roughly following a real road. It is not designed to reconstruct a real road from a sparse freehand sketch that deviates hundreds of meters from any path.

This matches the distinction raised earlier in #199 between **map matching** (clean up a real noisy recording) and **route reconstruction** (turn a freehand/waypoint path into a routed path) — they're different problems. 

This PR adds a client-side confidence check: after matching, if any original point ends up oddly far from the resulting line (more than `max(3 × gps_accuracy, 50)` meters), that segment's match is rejected and the original points are kept, with a toast notifying the user instead of silently applying a bad result.

### Routing profile and matching
I first thought that the selected routing profile didn't seem to affect the match. Traced this down: profile *does* affects  which roads are excluded as candidates (e.g. `foot` vs `motorbike` differ a lot), and which road wins when routing between ambiguous candidates. But `bike`/`racingbike`/`gravelbike`/`mtb` share the same hard access exclusions in this instance's config and only differ in `distance_influence`/surface weighting, so they converge to the same result except in genuinely ambiguous cases. (that's why switching between them looked like it had no effect)

Separately: GraphHopper's `/match` endpoint only accepts an XML/GPX POST body — there's no JSON body support and no way to pass a `custom_model` override per request (confirmed by tracing `MapMatchingResource` vs `RouteResource` in GraphHopper's source). So the private-roads-blocking custom model used for `/route` can't be applied to matching without patching GraphHopper itself. Out of scope for this PR.

## What changed since the initial version
- Fixed elevation being silently dropped to 0 on every matched point (`elevation=true` wasn't being requested; now has the same fallback chain as `/route`).
- Tightened `gps_accuracy` (candidate search radius) to reduce snapping to the wrong nearby road when multiple are close together.
- Added an explicit `max_visited_nodes` cap to bound worst-case latency on long/dense tracks.
- Segments are now matched in parallel per selected item, as before, but skip a doomed request entirely if a segment has fewer than 2 points.
- Failures (network errors, GraphHopper's "sequence is broken" error, too few points, low-confidence matches) now surface as toast notifications instead of silently keeping the original points with no feedback.

## Known dependency on production infra
This PR calls `https://graphhopper.gpx.studio/match`, mirroring how `/route` is already called. **`/match` is not currently exposed on that host** (only `/route` is — confirmed via direct testing, `/match` and even `/info` return a plain nginx 404). This needs to be exposed there the same way `/route` already is before this feature works in production. I believe don't have access to that myself (?).