### PR TITLE
add custom graphhopper API option, support official graphhopper.com API and self-host graphhopper

### DIFF
--- a/website/check-output.txt
+++ b/website/check-output.txt
@@ -1,0 +1,238 @@
+
+> website@0.0.1 check
+> svelte-kit sync && svelte-check --tsconfig ./tsconfig.json
+
+Loading svelte-check in workspace: c:\F\code\gpx.studio\website
+Getting Svelte diagnostics...
+
+c:\F\code\gpx.studio\website\[32msrc\lib\components\collapsible-tree\CollapsibleTree.svelte[39m:19:48
+[33mWarn[39m: This reference only captures the initial value of `defaultState`. Did you mean to reference it inside a derived instead?
+https://svelte.dev/e/state_referenced_locally (svelte)
+[36m
+    let open = $state(new CollapsibleTreeState([35mdefaultState[36m));[39m
+
+c:\F\code\gpx.studio\website\[32msrc\lib\components\collapsible-tree\CollapsibleTree.svelte[39m:22:41
+[33mWarn[39m: This reference only captures the initial value of `side`. Did you mean to reference it inside a closure instead?
+https://svelte.dev/e/state_referenced_locally (svelte)
+[36m    setContext('collapsible-tree-state', open);
+    setContext('collapsible-tree-side', [35mside[36m);
+    setContext('collapsible-tree-nohover', nohover);[39m
+
+c:\F\code\gpx.studio\website\[32msrc\lib\components\collapsible-tree\CollapsibleTree.svelte[39m:23:44
+[33mWarn[39m: This reference only captures the initial value of `nohover`. Did you mean to reference it inside a closure instead?
+https://svelte.dev/e/state_referenced_locally (svelte)
+[36m    setContext('collapsible-tree-side', side);
+    setContext('collapsible-tree-nohover', [35mnohover[36m);
+    setContext('collapsible-tree-parent-id', 'root');[39m
+
+c:\F\code\gpx.studio\website\[32msrc\lib\components\collapsible-tree\CollapsibleTree.svelte[39m:25:56
+[33mWarn[39m: This reference only captures the initial value of `slotInsideTrigger`. Did you mean to reference it inside a closure instead?
+https://svelte.dev/e/state_referenced_locally (svelte)
+[36m    setContext('collapsible-tree-parent-id', 'root');
+    setContext('collapsible-tree-slot-inside-trigger', [35mslotInsideTrigger[36m);
+</script>[39m
+
+c:\F\code\gpx.studio\website\[32msrc\lib\components\collapsible-tree\CollapsibleTreeNode.svelte[39m:22:33
+[33mWarn[39m: This reference only captures the initial value of `props`. Did you mean to reference it inside a closure instead?
+https://svelte.dev/e/state_referenced_locally (svelte)
+[36m
+    let fullId = `${parentId}.${[35m[36mprops.id}`;
+    setContext('collapsible-tree-parent-id', fullId);[39m
+
+c:\F\code\gpx.studio\website\[32msrc\lib\components\elevation-profile\elevation-profile.ts[39m:288:26
+[31mError[39m: Type '() => boolean' is not assignable to type 'boolean | undefined'. 
+[36m                },
+                reverse: [35m() => id === 'speed' && get(velocityUnits) === 'pace'[36m,
+                display: false,[39m
+
+c:\F\code\gpx.studio\website\[32msrc\lib\components\map\style.ts[39m:110:27
+[31mError[39m: 'e' is of type 'unknown'. 
+[36m        } catch (e) {
+            console.error([35me[36m.message);
+        }[39m
+
+c:\F\code\gpx.studio\website\[32msrc\lib\components\map\style.ts[39m:180:39
+[31mError[39m: 'e' is of type 'unknown'. 
+[36m                    } catch (e) {
+                        console.error([35me[36m.message);
+                    }[39m
+
+c:\F\code\gpx.studio\website\[32msrc\lib\components\map\map.ts[39m:119:20
+[31mError[39m: Property '_map' does not exist on type 'Window & typeof globalThis'. Did you mean 'Map'? 
+[36m            this._mapStore.set(map); // only set the store after the map has loaded
+            window.[35m_map[36m = map; // entry point for extensions
+            this.resize();[39m
+
+c:\F\code\gpx.studio\website\[32msrc\lib\components\file-list\sortable-file-list.ts[39m:2:42
+[31mError[39m: Could not find a declaration file for module 'sortablejs/Sortable'. 'c:/F/code/gpx.studio/website/node_modules/sortablejs/Sortable.js' implicitly has an 'any' type.
+  Try `npm i --save-dev @types/sortablejs` if it exists or add a new declaration (.d.ts) file containing `declare module 'sortablejs/Sortable';` 
+[36mimport { isMac } from '$lib/utils';
+import Sortable, { type Direction } from [35m'sortablejs/Sortable'[36m;
+import { ListItem, ListLevel, ListRootItem } from './file-list';[39m
+
+c:\F\code\gpx.studio\website\[32msrc\lib\components\file-list\sortable-file-list.ts[39m:121:67
+[31mError[39m: Parameter 'i' implicitly has an 'any' type. 
+[36m                let oldIndices: number[] =
+                    e.oldIndicies.length > 0 ? e.oldIndicies.map(([35mi[36m) => i.index) : [e.oldIndex];
+                oldIndices = oldIndices.filter((i) => i >= 0);[39m
+
+c:\F\code\gpx.studio\website\[32msrc\lib\components\file-list\sortable-file-list.ts[39m:136:67
+[31mError[39m: Parameter 'i' implicitly has an 'any' type. 
+[36m                let newIndices: number[] =
+                    e.newIndicies.length > 0 ? e.newIndicies.map(([35mi[36m) => i.index) : [e.newIndex];
+                newIndices = newIndices.filter((i) => i >= 0);[39m
+
+c:\F\code\gpx.studio\website\[32msrc\lib\components\map\layer-control\extension-api.ts[39m:88:13
+[31mError[39m: Element implicitly has an 'any' type because expression of type 'string' can't be used to index type 'boolean | LayerTreeType'.
+  No index signature with a parameter of type 'string' was found on type 'boolean | LayerTreeType'. 
+[36m        if (!overlayTree.overlays.hasOwnProperty(overlay.extensionName)) {
+            [35moverlayTree.overlays[overlay.extensionName][36m = {};
+        }[39m
+
+c:\F\code\gpx.studio\website\[32msrc\lib\components\map\layer-control\extension-api.ts[39m:91:9
+[31mError[39m: Element implicitly has an 'any' type because expression of type 'string' can't be used to index type 'boolean | LayerTreeType'.
+  No index signature with a parameter of type 'string' was found on type 'boolean | LayerTreeType'. 
+[36m
+        [35moverlayTree.overlays[overlay.extensionName][36m[overlay.id] = true;[39m
+
+c:\F\code\gpx.studio\website\[32msrc\lib\components\map\street-view-control\mapillary.ts[39m:2:49
+[31mError[39m: Could not find a declaration file for module 'mapillary-js/dist/mapillary.module'. 'c:/F/code/gpx.studio/website/node_modules/mapillary-js/dist/mapillary.module.js' implicitly has an 'any' type.
+  Try `npm i --save-dev @types/mapillary-js` if it exists or add a new declaration (.d.ts) file containing `declare module 'mapillary-js/dist/mapillary.module';` 
+[36mimport maplibregl, { type LayerSpecification, type VectorSourceSpecification } from 'maplibre-gl';
+import { Viewer, type ViewerBearingEvent } from [35m'mapillary-js/dist/mapillary.module'[36m;
+import 'mapillary-js/dist/mapillary.css';[39m
+
+c:\F\code\gpx.studio\website\[32msrc\lib\components\AlgoliaDocSearch.svelte[39m:63:70
+[31mError[39m: Type 'true' is not assignable to type '"" | "anonymous" | "use-credentials" | null | undefined'. (ts)
+[36m<svelte:head>
+    <link rel="preconnect" href="https://21XLD94PE3-dsn.algolia.net" [35mcrossorigin[36m />
+</svelte:head>[39m
+
+c:\F\code\gpx.studio\website\[32msrc\lib\components\map\layer-control\LayerTreeNode.svelte[39m:56:34
+[31mError[39m: Type 'boolean | LayerTreeType' is not assignable to type 'boolean | undefined'.
+  Type 'LayerTreeType' is not assignable to type 'boolean | undefined'. (ts)
+[36m                            value={id}
+                            bind:[35mchecked[36m={checked[id]}
+                            class="scale-90"[39m
+
+c:\F\code\gpx.studio\website\[32msrc\lib\components\map\layer-control\LayerTreeNode.svelte[39m:93:29
+[31mError[39m: Type 'boolean | LayerTreeType' is not assignable to type 'LayerTreeType'.
+  Type 'boolean' is not assignable to type 'LayerTreeType'. (ts)
+[36m                        <Self
+                            [35mnode[36m={node[id]}
+                            {name}[39m
+
+c:\F\code\gpx.studio\website\[32msrc\lib\components\map\layer-control\LayerTreeNode.svelte[39m:98:34
+[31mError[39m: Type 'boolean | LayerTreeType' is not assignable to type 'LayerTreeType'.
+  Type 'boolean' is not assignable to type 'LayerTreeType'. (ts)
+[36m                            {multiple}
+                            bind:[35mchecked[36m={checked[id]}
+                        />[39m
+
+c:\F\code\gpx.studio\website\[32msrc\lib\components\map\layer-control\CustomLayers.svelte[39m:258:21
+[31mError[39m: Element implicitly has an 'any' type because expression of type '"custom"' can't be used to index type 'boolean | LayerTreeType'.
+  Property 'custom' does not exist on type 'boolean | LayerTreeType'. (ts)
+[36m                    $customBasemapOrder = customBasemapItems.map((item) => item.id);
+                    [35m$selectedBasemapTree.basemaps['custom'][36m = customBasemapItems.reduce(
+                        (acc, item) => {[39m
+
+c:\F\code\gpx.studio\website\[32msrc\lib\components\map\layer-control\CustomLayers.svelte[39m:260:29
+[31mError[39m: Element implicitly has an 'any' type because expression of type 'string' can't be used to index type '{}'.
+  No index signature with a parameter of type 'string' was found on type '{}'. (ts)
+[36m                        (acc, item) => {
+                            [35macc[item.id][36m = true;
+                            return acc;[39m
+
+c:\F\code\gpx.studio\website\[32msrc\lib\components\map\layer-control\CustomLayers.svelte[39m:318:21
+[31mError[39m: Element implicitly has an 'any' type because expression of type '"custom"' can't be used to index type 'boolean | LayerTreeType'.
+  Property 'custom' does not exist on type 'boolean | LayerTreeType'. (ts)
+[36m                    $customOverlayOrder = customOverlayItems.map((item) => item.id);
+                    [35m$selectedOverlayTree.overlays['custom'][36m = customOverlayItems.reduce(
+                        (acc, item) => {[39m
+
+c:\F\code\gpx.studio\website\[32msrc\lib\components\map\layer-control\CustomLayers.svelte[39m:320:29
+[31mError[39m: Element implicitly has an 'any' type because expression of type 'string' can't be used to index type '{}'.
+  No index signature with a parameter of type 'string' was found on type '{}'. (ts)
+[36m                        (acc, item) => {
+                            [35macc[item.id][36m = true;
+                            return acc;[39m
+
+c:\F\code\gpx.studio\website\[32msrc\lib\components\file-list\FileListNodeContent.svelte[39m:28:9
+[33mWarn[39m: This reference only captures the initial value of `node`. Did you mean to reference it inside a closure instead?
+https://svelte.dev/e/state_referenced_locally (svelte)
+[36m    let sortableLevel: ListLevel =
+        [35m[36mnode instanceof Map
+            ? ListLevel.FILE[39m
+
+c:\F\code\gpx.studio\website\[32msrc\lib\components\file-list\FileListNodeContent.svelte[39m:30:15
+[33mWarn[39m: This reference only captures the initial value of `node`. Did you mean to reference it inside a closure instead?
+https://svelte.dev/e/state_referenced_locally (svelte)
+[36m            ? ListLevel.FILE
+            : [35m[36mnode instanceof GPXFile
+              ? waypointRoot[39m
+
+c:\F\code\gpx.studio\website\[32msrc\lib\components\file-list\FileListNodeContent.svelte[39m:31:17
+[33mWarn[39m: This reference only captures the initial value of `waypointRoot`. Did you mean to reference it inside a closure instead?
+https://svelte.dev/e/state_referenced_locally (svelte)
+[36m            : node instanceof GPXFile
+              ? [35m[36mwaypointRoot
+                  ? ListLevel.WAYPOINTS[39m
+
+c:\F\code\gpx.studio\website\[32msrc\lib\components\file-list\FileListNodeContent.svelte[39m:33:21
+[33mWarn[39m: This reference only captures the initial value of `item`. Did you mean to reference it inside a closure instead?
+https://svelte.dev/e/state_referenced_locally (svelte)
+[36m                  ? ListLevel.WAYPOINTS
+                  : [35m[36mitem instanceof ListWaypointsItem
+                    ? ListLevel.WAYPOINT[39m
+
+c:\F\code\gpx.studio\website\[32msrc\lib\components\file-list\FileListNodeContent.svelte[39m:36:17
+[33mWarn[39m: This reference only captures the initial value of `node`. Did you mean to reference it inside a closure instead?
+https://svelte.dev/e/state_referenced_locally (svelte)
+[36m                    : ListLevel.TRACK
+              : [35m[36mnode instanceof Track
+                ? ListLevel.SEGMENT[39m
+
+c:\F\code\gpx.studio\website\[32msrc\lib\components\file-list\FileListNodeLabel.svelte[39m:99:51
+[31mError[39m: Property '_data' does not exist on type 'Waypoint | Waypoint[] | GPXTreeElement<AnyGPXTreeElement>'.
+  Property '_data' does not exist on type 'Waypoint[]'. (ts)
+[36m    let hidden = $derived(
+        item.level === ListLevel.WAYPOINTS ? node.[35m_data[36m.hiddenWpt : node._data.hidden
+    );[39m
+
+c:\F\code\gpx.studio\website\[32msrc\lib\components\file-list\FileListNodeLabel.svelte[39m:99:74
+[31mError[39m: Property '_data' does not exist on type 'Waypoint | Waypoint[] | GPXTreeElement<AnyGPXTreeElement>'.
+  Property '_data' does not exist on type 'Waypoint[]'. (ts)
+[36m    let hidden = $derived(
+        item.level === ListLevel.WAYPOINTS ? node._data.hiddenWpt : node.[35m_data[36m.hidden
+    );[39m
+
+c:\F\code\gpx.studio\website\[32msrc\lib\components\file-list\FileList.svelte[39m:27:31
+[33mWarn[39m: This reference only captures the initial value of `orientation`. Did you mean to reference it inside a closure instead?
+https://svelte.dev/e/state_referenced_locally (svelte)
+[36m
+    setContext('orientation', [35morientation[36m);
+    setContext('recursive', recursive);[39m
+
+c:\F\code\gpx.studio\website\[32msrc\lib\components\file-list\FileList.svelte[39m:28:29
+[33mWarn[39m: This reference only captures the initial value of `recursive`. Did you mean to reference it inside a closure instead?
+https://svelte.dev/e/state_referenced_locally (svelte)
+[36m    setContext('orientation', orientation);
+    setContext('recursive', [35mrecursive[36m);[39m
+
+c:\F\code\gpx.studio\website\[32msrc\routes\[[language]]\help\[...guide]\+page.svelte[39m:12:51
+[31mError[39m: Argument of type 'string | undefined' is not assignable to parameter of type 'string'.
+  Type 'undefined' is not assignable to type 'string'. (ts)
+[36m
+    let previousGuide = $derived(getPreviousGuide([35mpage.params.guide[36m));
+    let nextGuide = $derived(getNextGuide(page.params.guide));[39m
+
+c:\F\code\gpx.studio\website\[32msrc\routes\[[language]]\help\[...guide]\+page.svelte[39m:13:43
+[31mError[39m: Argument of type 'string | undefined' is not assignable to parameter of type 'string'.
+  Type 'undefined' is not assignable to type 'string'. (ts)
+[36m    let previousGuide = $derived(getPreviousGuide(page.params.guide));
+    let nextGuide = $derived(getNextGuide([35mpage.params.guide[36m));
+</script>[39m
+
+====================================
+[31msvelte-check found 22 errors and 12 warnings in 15 files
+[39m

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -2721,9 +2721,6 @@
                 "arm"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -2741,9 +2738,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -2761,9 +2755,6 @@
                 "ppc64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -2781,9 +2772,6 @@
                 "riscv64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -2801,9 +2789,6 @@
                 "s390x"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -2821,9 +2806,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -2841,9 +2823,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -2861,9 +2840,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -2881,9 +2857,6 @@
                 "arm"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -2907,9 +2880,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -2933,9 +2903,6 @@
                 "ppc64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -2959,9 +2926,6 @@
                 "riscv64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -2985,9 +2949,6 @@
                 "s390x"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -3011,9 +2972,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -3037,9 +2995,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -3063,9 +3018,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -3482,9 +3434,6 @@
                 "arm"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3499,9 +3448,6 @@
                 "arm"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3516,9 +3462,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3533,9 +3476,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3550,9 +3490,6 @@
                 "loong64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3567,9 +3504,6 @@
                 "loong64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3584,9 +3518,6 @@
                 "ppc64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3601,9 +3532,6 @@
                 "ppc64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3618,9 +3546,6 @@
                 "riscv64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3635,9 +3560,6 @@
                 "riscv64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3652,9 +3574,6 @@
                 "s390x"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3669,9 +3588,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3686,9 +3602,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4034,9 +3947,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4054,9 +3964,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4074,9 +3981,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4094,9 +3998,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -5915,9 +5816,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -5939,9 +5837,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -5963,9 +5858,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -5987,9 +5879,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MPL-2.0",
             "optional": true,
             "os": [

--- a/website/src/lib/components/Menu.svelte
+++ b/website/src/lib/components/Menu.svelte
@@ -23,6 +23,7 @@
         Moon,
         Layers,
         ListTree,
+        Route,
         Languages,
         Settings,
         Info,
@@ -53,6 +54,7 @@
     import { anySelectedLayer } from '$lib/components/map/layer-control/utils';
     import { defaultOverlays } from '$lib/assets/layers';
     import LayerControlSettings from '$lib/components/map/layer-control/LayerControlSettings.svelte';
+    import RoutingSettings from '$lib/components/toolbar/tools/routing/RoutingSettings.svelte';
     import { ListFileItem, ListTrackItem } from '$lib/components/file-list/file-list';
     import Export from '$lib/components/export/Export.svelte';
     import { mode, setMode } from 'mode-watcher';
@@ -107,6 +109,7 @@
     }
 
     let layerSettingsOpen = $state(false);
+    let routingSettingsOpen = $state(false);
     let fullscreen = $state(false);
 
     function toggleFullscreen() {
@@ -526,6 +529,10 @@
                         <Layers size="16" />
                         {i18n._('menu.layers')}
                     </Menubar.Item>
+                    <Menubar.Item onclick={() => (routingSettingsOpen = true)}>
+                        <Route size="16" />
+                        {i18n._('toolbar.routing.provider.title')}
+                    </Menubar.Item>
                 </Menubar.Content>
             </Menubar.Menu>
         </Menubar.Root>
@@ -561,6 +568,7 @@
 
 <Export />
 <LayerControlSettings bind:open={layerSettingsOpen} />
+<RoutingSettings bind:open={routingSettingsOpen} />
 
 <svelte:window
     on:keydown={(e) => {

--- a/website/src/lib/components/toolbar/tools/routing/RoutingSettings.svelte
+++ b/website/src/lib/components/toolbar/tools/routing/RoutingSettings.svelte
@@ -1,0 +1,80 @@
+<script lang="ts">
+    import * as Sheet from '$lib/components/ui/sheet';
+    import * as Select from '$lib/components/ui/select';
+    import { ScrollArea } from '$lib/components/ui/scroll-area/index.js';
+    import { Label } from '$lib/components/ui/label';
+    import { Input } from '$lib/components/ui/input';
+    import { TriangleAlert } from '@lucide/svelte';
+    import { i18n } from '$lib/i18n.svelte';
+    import { settings } from '$lib/logic/settings';
+
+    const { routingProvider, graphhopperApiKey, graphhopperCustomUrl } = settings;
+
+    let { open = $bindable() }: { open: boolean } = $props();
+
+    const providers = ['default', 'official', 'custom'];
+</script>
+
+<Sheet.Root bind:open>
+    <Sheet.Trigger class="hidden" />
+    <Sheet.Content>
+        <Sheet.Header class="h-full">
+            <Sheet.Title>{i18n._('toolbar.routing.provider.title')}</Sheet.Title>
+            <ScrollArea class="w-[105%] min-h-full pr-4">
+                <Sheet.Description>
+                    {i18n._('toolbar.routing.provider.help')}
+                </Sheet.Description>
+                <div class="flex flex-col gap-4 mt-2">
+                    <div class="flex flex-col gap-1.5">
+                        <Label>{i18n._('toolbar.routing.provider.provider')}</Label>
+                        <Select.Root type="single" bind:value={$routingProvider}>
+                            <Select.Trigger class="w-full" size="sm">
+                                {i18n._(`toolbar.routing.provider.providers.${$routingProvider}`)}
+                            </Select.Trigger>
+                            <Select.Content>
+                                {#each providers as provider}
+                                    <Select.Item value={provider}>
+                                        {i18n._(`toolbar.routing.provider.providers.${provider}`)}
+                                    </Select.Item>
+                                {/each}
+                            </Select.Content>
+                        </Select.Root>
+                    </div>
+
+                    {#if $routingProvider === 'official'}
+                        <div class="flex flex-col gap-1.5">
+                            <Label>{i18n._('toolbar.routing.provider.api_key')}</Label>
+                            <Input
+                                type="text"
+                                autocomplete="off"
+                                spellcheck="false"
+                                placeholder={i18n._('toolbar.routing.provider.api_key_placeholder')}
+                                bind:value={$graphhopperApiKey}
+                            />
+                            <p
+                                class="flex flex-row gap-1.5 text-xs text-muted-foreground leading-snug"
+                            >
+                                <TriangleAlert size="14" class="shrink-0 mt-0.5" />
+                                {i18n._('toolbar.routing.provider.official_warning')}
+                            </p>
+                        </div>
+                    {:else if $routingProvider === 'custom'}
+                        <div class="flex flex-col gap-1.5">
+                            <Label>{i18n._('toolbar.routing.provider.custom_url')}</Label>
+                            <Input
+                                type="text"
+                                autocomplete="off"
+                                spellcheck="false"
+                                placeholder="https://graphhopper.gpx.studio/route"
+                                bind:value={$graphhopperCustomUrl}
+                            />
+                            <p class="text-xs text-muted-foreground leading-snug">
+                                {i18n._('toolbar.routing.provider.custom_url_help')}
+                            </p>
+                        </div>
+                    {/if}
+                </div>
+            </ScrollArea>
+        </Sheet.Header>
+    </Sheet.Content>
+</Sheet.Root>

--- a/website/src/lib/components/toolbar/tools/routing/routing.ts
+++ b/website/src/lib/components/toolbar/tools/routing/routing.ts
@@ -4,7 +4,11 @@ import { settings } from '$lib/logic/settings';
 import { getElevation } from '$lib/utils';
 import { get } from 'svelte/store';
 
-const { routing, routingProfile, privateRoads } = settings;
+const { routing, routingProfile, privateRoads, routingProvider, graphhopperApiKey, graphhopperCustomUrl } =
+    settings;
+
+const DEFAULT_GRAPHHOPPER_URL = 'https://graphhopper.gpx.studio/route';
+const OFFICIAL_GRAPHHOPPER_URL = 'https://graphhopper.com/api/1/route';
 
 export type RoutingProfile = {
     engine: 'graphhopper' | 'brouter';
@@ -109,39 +113,84 @@ async function getGraphHopperRoute(
     graphHopperProfile: string,
     privateRoads: boolean
 ): Promise<TrackPoint[]> {
-    let response = await fetch('https://graphhopper.gpx.studio/route', {
+    const provider = get(routingProvider);
+    const official = provider === 'official';
+
+    let url: string;
+    if (provider === 'official') {
+        url = `${OFFICIAL_GRAPHHOPPER_URL}?key=${encodeURIComponent(get(graphhopperApiKey))}`;
+    } else if (provider === 'custom') {
+        url = get(graphhopperCustomUrl).trim() || DEFAULT_GRAPHHOPPER_URL;
+    } else {
+        url = DEFAULT_GRAPHHOPPER_URL;
+    }
+
+    const customModel = privateRoads
+        ? {}
+        : graphhopperBlockPrivateCustomModels[graphHopperProfile] || {};
+    const hasCustomModel = Object.keys(customModel).length > 0;
+
+    // hike_rating / mtb_rating are only exposed by the self-hosted config; the
+    // official server would reject them, so request only the common details there.
+    const requestedDetails = official ? ['road_class', 'surface'] : graphhopperDetails;
+
+    const body: { [key: string]: any } = {
+        points: points.map((point) => [point.lon, point.lat]),
+        profile: graphHopperProfile,
+        elevation: true,
+        points_encoded: false,
+        details: requestedDetails,
+    };
+    if (official) {
+        // On the official API, sending any custom_model (even an empty one)
+        // requires ch.disable=true. When private roads are allowed we send no
+        // custom_model at all so the free plan's speed mode handles the request.
+        if (hasCustomModel) {
+            body.custom_model = customModel;
+            body['ch.disable'] = true;
+        }
+    } else {
+        body.custom_model = customModel;
+    }
+
+    let response = await fetch(url, {
         method: 'POST',
         headers: {
             'Content-Type': 'application/json',
         },
-        body: JSON.stringify({
-            points: points.map((point) => [point.lon, point.lat]),
-            profile: graphHopperProfile,
-            elevation: true,
-            points_encoded: false,
-            details: graphhopperDetails,
-            custom_model: privateRoads
-                ? {}
-                : graphhopperBlockPrivateCustomModels[graphHopperProfile] || {},
-        }),
+        body: JSON.stringify(body),
     });
 
     if (!response.ok) {
-        const error = await response.json();
-        if (error.message.includes('Cannot find point 0')) {
+        const error = await response.json().catch(() => ({}));
+        const message: string = error?.message ?? '';
+        const hintDetails: string = error?.hints?.[0]?.details ?? '';
+
+        if (message.includes('Cannot find point 0')) {
             throw new Error('toolbar.routing.error.from');
-        } else if (error.message.includes('Cannot find point 1')) {
+        } else if (message.includes('Cannot find point 1')) {
             if (points.length == 3) {
                 throw new Error('toolbar.routing.error.via');
             } else {
                 throw new Error('toolbar.routing.error.to');
             }
-        } else if (error.hints[0].details.includes('PointDistanceExceededException')) {
+        } else if (hintDetails.includes('PointDistanceExceededException')) {
             throw new Error('toolbar.routing.error.distance');
-        } else if (error.hints[0].details.includes('ConnectionNotFoundException')) {
+        } else if (hintDetails.includes('ConnectionNotFoundException')) {
             throw new Error('toolbar.routing.error.connection');
+        } else if (official && (response.status === 401 || /api key|unauthorized/i.test(message))) {
+            throw new Error('toolbar.routing.error.api_key');
+        } else if (official && (response.status === 429 || /limit|quota/i.test(message))) {
+            throw new Error('toolbar.routing.error.quota');
+        } else if (official && /profile/i.test(message)) {
+            throw new Error('toolbar.routing.error.profile');
+        } else if (
+            official &&
+            /custom_model|ch\.disable|encoded value|details/i.test(message)
+        ) {
+            throw new Error('toolbar.routing.error.unsupported_feature');
         } else {
-            throw new Error(error.message);
+            throw new Error(message || 'toolbar.routing.error.connection');
         }
     }
 
@@ -164,7 +213,7 @@ async function getGraphHopperRoute(
         );
     }
 
-    for (let key of graphhopperDetails) {
+    for (let key of requestedDetails) {
         let detail = details[key];
         for (let i = 0; i < detail.length; i++) {
             for (let j = detail[i][0]; j < detail[i][1] + (i == detail.length - 1); j++) {

--- a/website/src/lib/logic/settings.ts
+++ b/website/src/lib/logic/settings.ts
@@ -210,6 +210,7 @@ type RoutingProfile =
     | 'motorcycle'
     | 'water'
     | 'railway';
+type RoutingProvider = 'default' | 'official' | 'custom';
 type TerrainSource = 'mapterhorn';
 type StreetViewSource = 'mapillary' | 'google';
 
@@ -261,6 +262,13 @@ export const settings = {
         )
     ),
     privateRoads: new Setting('privateRoads', false),
+    routingProvider: new Setting<RoutingProvider>(
+        'routingProvider',
+        'default',
+        getValueValidator<RoutingProvider>(['default', 'official', 'custom'], 'default')
+    ),
+    graphhopperApiKey: new Setting<string>('graphhopperApiKey', ''),
+    graphhopperCustomUrl: new Setting<string>('graphhopperCustomUrl', ''),
     currentBasemap: new Setting(
         'currentBasemap',
         defaultBasemap,

--- a/website/src/locales/en.json
+++ b/website/src/locales/en.json
@@ -194,7 +194,26 @@
                 "to": "The end point is too far from the nearest road",
                 "distance": "The end point is too far from the start point",
                 "connection": "No connection found between the points",
-                "timeout": "Route calculation took too long, try adding points closer together"
+                "timeout": "Route calculation took too long, try adding points closer together",
+                "api_key": "Invalid or missing GraphHopper API key. Check your key in the routing API settings.",
+                "quota": "GraphHopper API request limit reached. Try again later or use another provider.",
+                "profile": "This activity is not supported by the official GraphHopper API (only bike, foot and car are available on the free plan). Switch to Bike or Run/hike, or use the default or a custom server.",
+                "unsupported_feature": "Blocking private roads is not supported by the official GraphHopper free plan. Turn on \"Allow private roads\", or use the default or a custom server."
+            },
+            "provider": {
+                "title": "Routing API",
+                "help": "Choose which GraphHopper routing server to use. The default server is provided by gpx.studio and requires no configuration.",
+                "provider": "Provider",
+                "providers": {
+                    "default": "Default (gpx.studio)",
+                    "official": "Official GraphHopper",
+                    "custom": "Custom URL"
+                },
+                "api_key": "API key",
+                "api_key_placeholder": "Your GraphHopper API key",
+                "official_warning": "On the free plan, only Bike, Run/hike and car are supported. Road bike, gravel bike, mountain bike and motorcycle, as well as private-road blocking, may not work.",
+                "custom_url": "API URL",
+                "custom_url_help": "Full URL of the GraphHopper route endpoint (e.g. https://your-server/route)."
             }
         },
         "scissors": {


### PR DESCRIPTION
Add configurable GraphHopper routing API provider

  Motivation

  Routing has always been hardcoded to the project's self-hosted GraphHopper instance
  (https://graphhopper.gpx.studio/route). That server's map data isn't necessarily updated very often, so recent changes
   in OpenStreetMap may take a while to show up in routing.

  This PR lets users choose which GraphHopper server to route against, so they aren't locked to a single update cadence:

  - Default (gpx.studio) — the current self-hosted server, no configuration needed.
  - Official GraphHopper API — graphhopper.com, which refreshes its map data roughly once per day.
  - Custom URL — point at your own self-hosted GraphHopper, which you can rebuild/update with fresh OSM data whenever
  you want.

  Changes

  New "Routing API" settings sheet (Settings menu → Routing API), mirroring the existing Layers settings sheet:
  - A provider dropdown (Default / Official / Custom).
  - An API key field for the official API (which requires a key).
  - A custom URL field for a self-hosted endpoint.

  These are stored as persisted settings (routingProvider, graphhopperApiKey, graphhopperCustomUrl) alongside the
  existing routing settings.

  Request handling (routing.ts) now builds the endpoint and request body per provider:
  - Default/Custom → self-hosted request shape, unchanged.
  - Official → ?key=… auth, and the request is adapted to the free-plan constraints.

  Handling the differences between the self-hosted config and the official API. The self-hosted server runs a custom
  config (extra profiles, custom encoded values like bike_road_access, and hike_rating/mtb_rating path details) that the
   official free plan doesn't support. So for the official provider:
  - "Allow private roads" ON → no custom_model is sent, so plain speed-mode routing works on the free plan.
  - "Allow private roads" OFF → blocking private roads relies on a paid/custom feature the free plan lacks, so it
  surfaces a clear toast telling the user to enable "Allow private roads" or switch servers.
  - Only the commonly-supported path details (road_class, surface) are requested, avoiding "detail not found" errors
  from the self-hosted-only ones.

  Clear, actionable error messages. API errors are mapped to friendly toasts for: invalid/missing API key, request-quota
   limits, unsupported activity profiles (the free plan only supports bike/foot/car), and unsupported custom-model
  features. New i18n strings were added to en.json.

  Notes

  - Existing default routing behavior is unchanged for users who don't touch the new setting.
  - Only en.json was updated; other locales are Crowdin-managed and fall back to English.


<img width="870" height="479" alt="image" src="https://github.com/user-attachments/assets/1a05f367-01e2-47a6-a5ee-814114fcaf20" />
