### PR TITLE
Add a containerised development server

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.git
+.DS_Store
+node_modules
+gpx/dist
+website/build
+website/.svelte-kit

--- a/README.md
+++ b/README.md
@@ -51,6 +51,18 @@ npm install
 npm run dev
 ```
 
+### Running the website with Docker
+
+Alternatively, the development server can run in a container, which pins Node to the same version used for deployment and avoids installing anything locally. You still need the `.env` file described above, and you still edit the files on your machine as usual.
+
+```bash
+docker compose up
+```
+
+The site is served on [http://localhost:5173](http://localhost:5173). Set `DEV_PORT` if that port is already taken. Dependencies are installed into Docker volumes on the first run, which takes a few minutes; later runs start in seconds, and the container reinstalls automatically whenever a lockfile changes.
+
+Note that file changes are picked up by polling, because file system events do not cross the container boundary reliably on macOS. If hot reloading works for you with `CHOKIDAR_USEPOLLING=0`, you can turn polling off and save some CPU.
+
 ## Credits
 
 This project has been made possible thanks to the following open source projects:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,46 @@
+# Local development server, containerised.
+#
+# Usage:  docker compose up        (then open http://localhost:5173)
+#
+services:
+    web:
+        image: node:24-bookworm-slim
+        init: true
+        working_dir: /app/website
+        entrypoint: ['/bin/sh', '/app/docker/dev-entrypoint.sh']
+        command: ['npx', 'vite', 'dev', '--host', '0.0.0.0', '--strictPort']
+        ports:
+            # Set DEV_PORT if something on the host already holds 5173. Vite's
+            # HMR client connects back to whatever host:port the page was loaded
+            # from, so remapping needs no extra config.
+            - '${DEV_PORT:-5173}:5173'
+        environment:
+            # macOS fsevents do not fully propagate into the Linux VM (VirtioFS
+            # still drops delete events), so Vite's watcher has to poll or HMR
+            # appears dead. Both Vite's bundled chokidar 3 and the chokidar 4
+            # SvelteKit uses read these, which is why no vite.config.ts change
+            # is needed. Try CHOKIDAR_USEPOLLING=0 to see if your Docker Desktop
+            # forwards events natively.
+            CHOKIDAR_USEPOLLING: '1'
+            CHOKIDAR_INTERVAL: '300'
+            # Normally the key comes from the bind-mounted website/.env. This is
+            # an escape hatch for a fresh clone that has no .env yet, since
+            # $env/static/public fails hard at import without it.
+            PUBLIC_MAPTILER_KEY: ${PUBLIC_MAPTILER_KEY:-}
+        volumes:
+            - .:/app
+            # The host's node_modules hold darwin-arm64 binaries (esbuild,
+            # rollup, lightningcss, sharp). These named volumes shadow them with
+            # the container's own linux-arm64 trees. They also isolate
+            # node_modules/.vite and node_modules/.cache/imagetools per side.
+            - gpx_node_modules:/app/gpx/node_modules
+            - website_node_modules:/app/website/node_modules
+            - npm_cache:/root/.npm
+            # Records which lockfiles the current node_modules were built from.
+            - dev_state:/state
+
+volumes:
+    gpx_node_modules:
+    website_node_modules:
+    npm_cache:
+    dev_state:

--- a/docker/dev-entrypoint.sh
+++ b/docker/dev-entrypoint.sh
@@ -1,0 +1,55 @@
+#!/bin/sh
+# Entrypoint for the dev container.
+#
+# Installs the two dependency trees into their named volumes on first run, and
+# reinstalls whenever a lockfile changes, so `docker compose up` never boots on
+# a stale node_modules.
+set -e
+
+REPO=/app
+STATE=/state
+
+needs_install() {
+    # The volume was wiped (npm's hidden lockfile is gone) -> reinstall.
+    [ -f "$REPO/gpx/node_modules/.package-lock.json" ] || return 0
+    [ -f "$REPO/website/node_modules/.package-lock.json" ] || return 0
+    # A lockfile changed since the last successful install -> reinstall.
+    cmp -s "$REPO/gpx/package-lock.json" "$STATE/gpx-lock.json" || return 0
+    cmp -s "$REPO/website/package-lock.json" "$STATE/website-lock.json" || return 0
+    return 1
+}
+
+if needs_install; then
+    echo "==> Installing dependencies (first run, or a lockfile changed). This takes a few minutes the first time."
+
+    # Order matters. website depends on gpx via `file:../gpx`; npm does not
+    # hoist a linked package's dependencies, so fast-xml-parser and immer only
+    # ever live in gpx/node_modules. gpx's postinstall also runs tsc, which it
+    # resolves from gpx/node_modules/.bin. Same order as
+    # .github/workflows/deploy.yml.
+    #
+    # Never add --omit=optional (sharp would fall back to compiling libvips
+    # from source on this slim image) and never set NODE_ENV=production (it
+    # would drop typescript and break gpx's postinstall).
+    if ! npm ci --prefix "$REPO/gpx" || ! npm ci --prefix "$REPO/website"; then
+        cat >&2 <<'MSG'
+
+==> npm ci failed.
+
+If the error mentions the lockfile being out of sync, then gpx/package.json has
+drifted from website/package-lock.json. CI uses `npm install`, which papers over
+this, so the drift can sit unnoticed on main. Refresh the locks on the host and
+try again:
+
+    npm install --prefix gpx && npm install --prefix website
+
+MSG
+        exit 1
+    fi
+
+    cp "$REPO/gpx/package-lock.json" "$STATE/gpx-lock.json"
+    cp "$REPO/website/package-lock.json" "$STATE/website-lock.json"
+    echo "==> Dependencies ready."
+fi
+
+exec "$@"


### PR DESCRIPTION
Running the site locally currently means installing two dependency trees by hand, and it builds against whatever Node version happens to be on the machine (Node 22 here, while CI deploys with Node 24). This adds an optional Docker setup so `docker compose up` is enough to get a dev server on port 5173, pinned to the same Node version CI uses.

Editing still happens on the host; only Node and Vite run in the container. The host's own node_modules are left untouched and are deliberately hidden from the container by named volumes, since they contain darwin-arm64 binaries for esbuild, rollup, lightningcss and sharp.

The entrypoint installs gpx before website, matching the deploy workflow: npm does not hoist a linked package's dependencies, and gpx's postinstall resolves tsc from its own node_modules. It records the lockfiles it installed from, so a later `up` reinstalls when they change instead of booting on a stale volume.